### PR TITLE
fix parsing in routeviews and implement finder in ris

### DIFF
--- a/cmd/bgpf/main.go
+++ b/cmd/bgpf/main.go
@@ -79,20 +79,20 @@ func (c *FilesCmd) Run(log bgpfinder.Logger, cli BgpfCLI) error {
 		return fmt.Errorf("failed to parse 'until' time: %v", err)
 	}
 
-	proj := bgpfinder.Project{Name: c.Project}
-	colls := []bgpfinder.Collector{}
+	project := bgpfinder.Project{Name: c.Project}
+	collectors := []bgpfinder.Collector{}
+
 	for _, c := range c.Collectors {
-		colls = append(colls,
+		collectors = append(collectors,
 			bgpfinder.Collector{
-				Project: proj,
+				Project: project,
 				Name:    c,
-				// no internal name
 			},
 		)
 	}
 
 	query := bgpfinder.Query{
-		Collectors: colls,
+		Collectors: collectors,
 		From:       fromTime,
 		Until:      untilTime,
 		DumpType:   c.Type,
@@ -142,7 +142,7 @@ func handleSignals(ctx context.Context, log bgpfinder.Logger, cancel context.Can
 			case <-ctx.Done():
 				return
 			case <-sigCh:
-				log.Info().Msgf("Signal recevied, triggering shutdown")
+				log.Info().Msgf("Signal received, triggering shutdown")
 				cancel()
 				return
 			}
@@ -163,7 +163,7 @@ func main() {
 	var cliCfg BgpfCLI
 	k := kong.Parse(&cliCfg,
 		kong.Vars{
-			"dump_type_def":  bgpfinder.DUMP_TYPE_ANY.String(),
+			"dump_type_def":  bgpfinder.DumpTypeAny.String(),
 			"dump_type_opts": dumpOptsStr(),
 		},
 	)

--- a/default.go
+++ b/default.go
@@ -34,6 +34,6 @@ func GetCollector(name string) (Collector, error) {
 	return DefaultFinder.Collector(name)
 }
 
-func Find(query Query) ([]File, error) {
+func Find(query Query) ([]BGPDump, error) {
 	return DefaultFinder.Find(query)
 }

--- a/finder.go
+++ b/finder.go
@@ -6,25 +6,24 @@ import (
 	"time"
 )
 
-// Just a sketch of what the base Finder interface might look like.  Everything
+// Finder Just a sketch of what the base Finder interface might look like.  Everything
 // gets built on top of (or under, I guess) this.
 type Finder interface {
-	// Get the list of projects supported by this finder
+	// Projects gets the list of projects supported by this finder
 	Projects() ([]Project, error)
 
-	// Get a specific project
+	// Project gets a specific project
 	Project(name string) (Project, error)
 
-	// Get the list of collectors supported by the given project. All
+	// Collectors gets the list of collectors supported by the given project. All
 	// projects if unset.
 	Collectors(project string) ([]Collector, error)
 
-	// Get a specific collector by name, returns the zero collector if there
-	// is no such collector
+	// Collector gets a specific collector by name
 	Collector(name string) (Collector, error)
 
 	// Find all the BGP data URLs that match the given query
-	Find(query Query) ([]File, error)
+	Find(query Query) ([]BGPDump, error)
 }
 
 type Project struct {
@@ -45,12 +44,7 @@ type Collector struct {
 
 	// Name of the collector
 	Name string `json:"name"`
-
-	// Project-internal name for this collector
-	InternalName string `json:"internal_name"`
 }
-
-var ZeroCollector = Collector{}
 
 func (c Collector) String() string {
 	return fmt.Sprintf("%s:%s", c.Project, c.Name)
@@ -60,7 +54,6 @@ func (c Collector) AsCSV() string {
 	return strings.Join([]string{
 		c.Project.AsCSV(),
 		c.Name,
-		c.InternalName,
 	}, ",")
 }
 
@@ -70,14 +63,12 @@ func (c Collector) AsCSV() string {
 type DumpType uint8
 
 const (
-	DUMP_TYPE_ANY     DumpType = 0 // any
-	DUMP_TYPE_RIB     DumpType = 1 // rib
-	DUMP_TYPE_UPDATES DumpType = 2 // updates
+	DumpTypeAny     DumpType = 0 // any
+	DumpTypeRib     DumpType = 1 // rib
+	DumpTypeUpdates DumpType = 2 // updates
 )
 
-// TODO: think about how this should work -- just keep it simple! no
-// complex query structures
-//
+// TODO: think about how this should work -- just keep it simple! no complex query structures
 // TODO: add Validate method (e.g., From is before Until, IsADumpType, etc.)
 type Query struct {
 	// Collectors to search for. All collectors if unset/empty
@@ -93,9 +84,8 @@ type Query struct {
 	DumpType DumpType
 }
 
-// Represents a single BGP file found by a Finder.
-// TODO: better name for this. Dump is a candidate.
-type File struct {
+// BGPDump represents a single BGP file found by a Finder.
+type BGPDump struct {
 	// URL of the file
 	URL string
 
@@ -105,7 +95,6 @@ type File struct {
 	// Nominal dump duration
 	Duration time.Duration
 
-	// Dump type
 	DumpType DumpType
 
 	// TODO: other things? (file size?)

--- a/multi.go
+++ b/multi.go
@@ -115,17 +115,29 @@ func (m *MultiFinder) Collector(name string) (Collector, error) {
 	return Collector{}, nil
 }
 
-func (m *MultiFinder) Find(query Query) ([]File, error) {
-	// TODO: only send the query to the appropriate finders
-	files := []File{}
-	for proj, f := range m.getFinders() {
-		pF, err := f.Find(query)
-		if err != nil {
-			return nil, fmt.Errorf("find failed for %s: %v", proj, err)
-		}
-		files = append(files, pF...)
+func (m *MultiFinder) Find(query Query) ([]BGPDump, error) {
+	dumps := []BGPDump{}
+
+	// Extract the project name from the query's collectors
+	if len(query.Collectors) == 0 {
+		return nil, fmt.Errorf("no collectors specified in query")
 	}
-	return files, nil
+	projectName := query.Collectors[0].Project.Name
+
+	// Get the appropriate finder for the specified project
+	finder, exists := m.getFinderByProject(projectName)
+	if !exists {
+		return nil, fmt.Errorf("unknown project: '%s'", projectName)
+	}
+
+	// Perform the search using the appropriate finder
+	dump, err := finder.Find(query)
+	if err != nil {
+		return nil, fmt.Errorf("find failed for %s: %v", projectName, err)
+	}
+	dumps = append(dumps, dump...)
+
+	return dumps, nil
 }
 
 func (m *MultiFinder) getFinderByProject(projName string) (Finder, bool) {

--- a/ris.go
+++ b/ris.go
@@ -15,11 +15,13 @@ const (
 	// RISCollectorsUrl : it's tempting, but we can't use
 	// https://www.ris.ripe.net/peerlist/ because it only lists
 	// currently-active collectors.
-	RISCollectorsUrl = "https://ris.ripe.net/docs/route-collectors/"
+	RISCollectorsUrl  = "https://ris.ripe.net/docs/route-collectors/"
+	RISUpdateDuration = time.Hour
+	RISRibDuration    = time.Minute * 15
 )
 
 var (
-	RIS_PROJECT   = Project{Name: RIS}
+	RisProject    = Project{Name: RIS}
 	risRRCPattern = regexp.MustCompile(`(rrc\d\d)`)
 )
 
@@ -45,12 +47,12 @@ func NewRISFinder() *RISFinder {
 }
 
 func (f *RISFinder) Projects() ([]Project, error) {
-	return []Project{RIS_PROJECT}, nil
+	return []Project{RisProject}, nil
 }
 
 func (f *RISFinder) Project(name string) (Project, error) {
 	if name == "" || name == RIS {
-		return RIS_PROJECT, nil
+		return RisProject, nil
 	}
 	return Project{}, nil
 }
@@ -106,7 +108,7 @@ func (f *RISFinder) Find(query Query) ([]BGPDump, error) {
 		for _, dateDir := range dateDirs {
 			date, err := time.Parse("2006.01", strings.TrimSuffix(dateDir, "/"))
 			if err != nil {
-				// some dateDir do not conform to the format and can be safely ignored
+				// some dateDir such as logs/, latest/ do not conform to the format and can be safely ignored
 				continue
 			}
 
@@ -152,7 +154,7 @@ func (f *RISFinder) scrapeFilesFromDateDir(dateDirLink string, allowedPrefixes [
 						results = append(results, BGPDump{
 							URL:       dateDirLink + file,
 							Collector: collector,
-							Duration:  time.Minute * 15,
+							Duration:  RISUpdateDuration,
 							DumpType:  DumpTypeUpdates,
 						})
 					}
@@ -160,7 +162,7 @@ func (f *RISFinder) scrapeFilesFromDateDir(dateDirLink string, allowedPrefixes [
 						results = append(results, BGPDump{
 							URL:       dateDirLink + file,
 							Collector: collector,
-							Duration:  time.Hour,
+							Duration:  RISRibDuration,
 							DumpType:  DumpTypeRib,
 						})
 					}
@@ -186,7 +188,7 @@ func (f *RISFinder) getCollectors() ([]Collector, error) {
 		}
 		// fmt.Printf("Debug: link:%s, m:%s\n", link, m)
 		collectors = append(collectors, Collector{
-			Project: RIS_PROJECT,
+			Project: RisProject,
 			Name:    m[1],
 		})
 	}

--- a/ris.go
+++ b/ris.go
@@ -3,24 +3,23 @@ package bgpfinder
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/alistairking/bgpfinder/scraper"
 )
 
 const (
-	RIS             = "ris"
-	RIS_ARCHIVE_URL = "https://data.ris.ripe.net/"
-	// XXX: it's tempting, but we can't use
+	RIS = "ris"
+	// RISCollectorsUrl : it's tempting, but we can't use
 	// https://www.ris.ripe.net/peerlist/ because it only lists
 	// currently-active collectors.
-	RIS_COLLECTORS_URL = RIS_ARCHIVE_URL
+	RISCollectorsUrl = "https://ris.ripe.net/docs/route-collectors/"
 )
 
 var (
-	RIS_PROJECT = Project{Name: RIS}
-
-	// RIS collectors are easy to find...
+	RIS_PROJECT   = Project{Name: RIS}
 	risRRCPattern = regexp.MustCompile(`(rrc\d\d)`)
 )
 
@@ -80,34 +79,120 @@ func (f *RISFinder) Collector(name string) (Collector, error) {
 	return Collector{}, nil
 }
 
-func (f *RISFinder) Find(query Query) ([]File, error) {
-	// TODO
-	return nil, nil
+// Find the BGP data corresponding to the query
+// The naming scheme for BGP data is as follows:
+// https://data.ris.ripe.net/rrcXX/YYYY.MM/TYPE.YYYYMMDD.HHmm.gz
+func (f *RISFinder) Find(query Query) ([]BGPDump, error) {
+	var results []BGPDump
+	var allowedPrefixes []string
+
+	if query.DumpType == DumpTypeRib || query.DumpType == DumpTypeAny {
+		allowedPrefixes = append(allowedPrefixes, "bview.")
+	}
+	if query.DumpType == DumpTypeUpdates || query.DumpType == DumpTypeAny {
+		allowedPrefixes = append(allowedPrefixes, "updates.")
+	}
+
+	for _, collector := range query.Collectors {
+		// baseURL: https://data.ris.ripe.net/rrcXX
+		baseUrl := "https://data.ris.ripe.net/" + collector.Name
+		fmt.Println("Scraping ", baseUrl)
+		dateDirs, err := scraper.ScrapeLinks(baseUrl)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scrape %s : %v", baseUrl, err)
+		}
+
+		// dateDir: YYYY.MM
+		for _, dateDir := range dateDirs {
+			date, err := time.Parse("2006.01", strings.TrimSuffix(dateDir, "/"))
+			if err != nil {
+				// some dateDir do not conform to the format and can be safely ignored
+				continue
+			}
+
+			if dateInRange(date, query) {
+				dateDirLink := baseUrl + "/" + dateDir
+				dateDirResults, err := f.scrapeFilesFromDateDir(dateDirLink, allowedPrefixes, collector, query)
+				if err != nil {
+					fmt.Printf("Warning: failed to process %s: %v\n", dateDirLink, err)
+					continue
+				}
+				results = append(results, dateDirResults...)
+
+			}
+		}
+	}
+	return results, nil
 }
 
+// scrapeFilesFromDateDir
+func (f *RISFinder) scrapeFilesFromDateDir(dateDirLink string, allowedPrefixes []string, collector Collector, query Query) ([]BGPDump, error) {
+	var results []BGPDump
+
+	fmt.Println("Scraping ", dateDirLink)
+	files, err := scraper.ScrapeLinks(dateDirLink)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scrape %s: %v", dateDirLink, err)
+	}
+
+	// file: TYPE.YYYYMMDD.HHmm.gz
+	for _, file := range files {
+		for _, prefix := range allowedPrefixes {
+			if strings.HasPrefix(file, prefix) {
+				parts := strings.Split(file, ".")
+				fileType := parts[0]
+				fileDateStr := parts[1] // "20060101"
+				fileDate, err := time.Parse("20060102", fileDateStr)
+				if err != nil {
+					fmt.Printf("Error parsing date %s from file %s: %v\n", fileDateStr, file, err)
+					continue
+				}
+				if dateInRange(fileDate, query) {
+					if fileType == "updates" {
+						results = append(results, BGPDump{
+							URL:       dateDirLink + file,
+							Collector: collector,
+							Duration:  time.Minute * 15,
+							DumpType:  DumpTypeUpdates,
+						})
+					}
+					if fileType == "bview" || fileType == "view" {
+						results = append(results, BGPDump{
+							URL:       dateDirLink + file,
+							Collector: collector,
+							Duration:  time.Hour,
+							DumpType:  DumpTypeRib,
+						})
+					}
+				}
+			}
+		}
+	}
+	return results, nil
+}
+
+// getCollectors fetches ALL Ris collectors
 func (f *RISFinder) getCollectors() ([]Collector, error) {
-	links, err := scraper.ScrapeLinks(RIS_COLLECTORS_URL)
+	links, err := scraper.ScrapeLinks(RISCollectorsUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get collector list: %v", err)
 	}
-	// RRCs are easy to find.. perhaps a little too easy.. so let's throw
-	// away dups
-	seen := map[string]struct{}{}
-	colls := []Collector{}
+
+	var collectors []Collector
 	for _, link := range links {
 		m := risRRCPattern.FindStringSubmatch(link)
 		if len(m) != 2 {
 			continue
 		}
-		c := m[1]
-		if _, exists := seen[c]; !exists {
-			colls = append(colls, Collector{
-				Project:      RIS_PROJECT,
-				Name:         m[1],
-				InternalName: m[1],
-			})
-			seen[c] = struct{}{}
-		}
+		// fmt.Printf("Debug: link:%s, m:%s\n", link, m)
+		collectors = append(collectors, Collector{
+			Project: RIS_PROJECT,
+			Name:    m[1],
+		})
 	}
-	return colls, nil
+	return collectors, nil
+}
+
+func dateInRange(date time.Time, query Query) bool {
+	return (date.Equal(query.From) || date.After(query.From)) && date.Before(query.Until)
 }

--- a/routeviews.go
+++ b/routeviews.go
@@ -122,7 +122,10 @@ func (f *RouteViewsFinder) getCollectors() ([]Collector, error) {
 		link = strings.TrimSuffix(link, "/bgpdata")
 		link = strings.TrimPrefix(link, "/")
 
-		// fmt.Println("Debug: link is: ", link)
+		// Handle the only special case for now. This is needed because collector.Name is used in other places
+		if link == "" {
+			link = "route-views2"
+		}
 
 		collectors = append(collectors, Collector{
 			Project: RouteviewsProject,
@@ -134,12 +137,14 @@ func (f *RouteViewsFinder) getCollectors() ([]Collector, error) {
 
 // getCollectorURL constructs the collector URL from collector name
 func (f *RouteViewsFinder) getCollectorURL(collector Collector) string {
+	// usually a collector's url is https://archive.routeviews.org/<collector.Name>bgpdata/
+	// but for route-views2, the url is https://archive.routeviews.org/bgpdata/
 	CollectorNameOverride := map[string]string{
 		"route-views2": "",
 	}
 
 	if override, exists := CollectorNameOverride[collector.Name]; exists {
-		collector.Name = override
+		return RouteviewsArchiveUrl + override + "/bgpdata/"
 	}
 
 	return RouteviewsArchiveUrl + collector.Name + "/bgpdata/"
@@ -155,7 +160,7 @@ func (f *RouteViewsFinder) dumpTypeURL(coll Collector, month time.Time, rvdt str
 
 // Find BGP dumps matching the specified query
 func (f *RouteViewsFinder) Find(query Query) ([]BGPDump, error) {
-	// Use all collectors if non are specified
+	// Use all collectors if none are specified
 	if len(query.Collectors) == 0 {
 		var err error
 		query.Collectors, err = f.Collectors("")


### PR DESCRIPTION
This PR implements the following:
- update variables, function names, comments to use Go conventions
- use full collector name internally (removed short names for collectors)
- make default finder choose the correct finder based on project name 
- implement finder for RIS

We don't have testing yet so there might be bugs somewhere. I tested the following commands and the results they returned seem to be reasonable. Will add more testing in the next steps. 

```
./bgpf collectors --project routeviews
./bgpf collectors --project ris
./bgpf files --project=routeviews --collectors=route-views2 --from="3/1/2014" --until="3/2/2014""
./bgpf files --project=ris --collectors=rrc02 --from="3/1/2006" --until="3/2/2006""
```