### PR TITLE
Updating schema of collectors table to include timestamp which holds …

### DIFF
--- a/cmd/bgpfinder-server/main.go
+++ b/cmd/bgpfinder-server/main.go
@@ -338,7 +338,8 @@ func dataHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc {
 
 				// Optionally, upsert the fetched data into the DB for future caching
 				if len(results) > 0 {
-					err = bgpfinder.UpsertBGPDumps(r.Context(), logger, db, results)
+					time := time.Now().UTC().Unix()
+					err = bgpfinder.UpsertBGPDumps(r.Context(), logger, db, results, &time)
 					if err != nil {
 						logger.Error().Err(err).Msg("Failed to upsert newly fetched BGP dumps into DB")
 						// Continue without failing the request

--- a/db.go
+++ b/db.go
@@ -2,6 +2,7 @@ package bgpfinder
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -10,7 +11,11 @@ import (
 )
 
 // UpsertCollectors inserts or updates collector records.
-func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, collectors []Collector) error {
+func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, collectors []Collector, currentTime *int64) error {
+	if currentTime == nil {
+		return fmt.Errorf("Error occurred: currentTime passed was nil")
+	}
+
 	tx, err := db.Begin(ctx)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to begin transaction for UpsertCollectors")
@@ -19,16 +24,17 @@ func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.P
 	defer tx.Rollback(ctx)
 
 	stmt := `
-        INSERT INTO collectors (name, project_name)
-        VALUES ($1, $2)
+        INSERT INTO collectors (name, project_name, last_fetch_timestamp)
+        VALUES ($1, $2, to_timestamp($3))
         ON CONFLICT (name) DO UPDATE
         SET project_name = EXCLUDED.project_name
+		SET last_fetch_timestamp = EXCLUDED.last_fetch_timestamp
     `
 
 	logger.Info().Int("collector_count", len(collectors)).Msg("Upserting collectors into DB")
 	for _, c := range collectors {
 		logger.Debug().Str("collector", c.Name).Str("project", c.Project.Name).Msg("Executing upsert for collector")
-		ct, err := tx.Exec(ctx, stmt, c.Name, c.Project.Name)
+		ct, err := tx.Exec(ctx, stmt, c.Name, c.Project.Name, *currentTime)
 		if err != nil {
 			logger.Error().Err(err).Str("collector", c.Name).Msg("Failed to execute upsert")
 			return err
@@ -47,7 +53,11 @@ func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.P
 }
 
 // UpsertBGPDumps inserts or updates BGP dump records in batches.
-func UpsertBGPDumps(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, dumps []BGPDump) error {
+func UpsertBGPDumps(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, dumps []BGPDump, currentTime *int64) error {
+	if currentTime == nil {
+		return fmt.Errorf("Error occurred: currentTime passed was nil")
+	}
+
 	const batchSize = 10000 // Define an appropriate batch size
 
 	total := len(dumps)
@@ -66,16 +76,17 @@ func UpsertBGPDumps(ctx context.Context, logger *logging.Logger, db *pgxpool.Poo
 		}
 
 		stmt := `
-			INSERT INTO bgp_dumps (collector_name, url, dump_type, duration, timestamp)
-			VALUES ($1, $2, $3, $4, to_timestamp($5))
+			INSERT INTO bgp_dumps (collector_name, url, dump_type, duration, timestamp, first_fetch_timestamp, last_fetch_timestamp)
+			VALUES ($1, $2, $3, $4, to_timestamp($5), to_timestamp($6), to_timestamp($7))
 			ON CONFLICT (collector_name, url) DO UPDATE
 			SET dump_type = EXCLUDED.dump_type,
 				duration = EXCLUDED.duration,
-				timestamp = EXCLUDED.timestamp
+				timestamp = EXCLUDED.timestamp,
+				last_fetch_timestamp = EXCLUDED.last_fetch_timestamp
 		`
 
 		for _, d := range batch {
-			_, err := tx.Exec(ctx, stmt, d.Collector.Name, d.URL, int16(d.DumpType), d.Duration, d.Timestamp)
+			_, err := tx.Exec(ctx, stmt, d.Collector.Name, d.URL, int16(d.DumpType), d.Duration, d.Timestamp, *currentTime, *currentTime)
 			if err != nil {
 				logger.Error().Err(err).Str("collector", d.Collector.Name).Str("url", d.URL).Msg("Failed to execute upsert for BGP dump")
 				tx.Rollback(ctx)

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -1,7 +1,8 @@
 CREATE TABLE IF NOT EXISTS collectors (
     collector_id SERIAL PRIMARY KEY,
     name VARCHAR(255) UNIQUE NOT NULL,
-    project_name VARCHAR(255) NOT NULL
+    project_name VARCHAR(255) NOT NULL,
+    last_prefetch_timestamp TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS bgp_dumps (

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -2,8 +2,8 @@ CREATE TABLE IF NOT EXISTS collectors (
     collector_id SERIAL PRIMARY KEY,
     name VARCHAR(255) UNIQUE NOT NULL,
     project_name VARCHAR(255) NOT NULL,
-    last_fetch_timestamp TIMESTAMP,
-    last_request_timestamp TIMESTAMP
+    last_fetch_timestamp TIMESTAMP NOT NULL DEFAULT GETDATE(),
+    last_request_timestamp TIMESTAMP NOT NULL DEFAULT GETDATE()
 );
 
 CREATE TABLE IF NOT EXISTS bgp_dumps (
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS bgp_dumps (
     dump_type SMALLINT NOT NULL,
     duration INTERVAL,
     timestamp TIMESTAMP NOT NULL,
-    first_fetch_timestamp TIMESTAMP,
-    last_fetch_timestamp TIMESTAMP,
+    first_fetch_timestamp TIMESTAMP NOT NULL DEFAULT GETDATE(),
+    last_fetch_timestamp TIMESTAMP NOT NULL DEFAULT GETDATE(),
     CONSTRAINT unique_bgp_dump UNIQUE (collector_name, url)
 );

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -2,7 +2,8 @@ CREATE TABLE IF NOT EXISTS collectors (
     collector_id SERIAL PRIMARY KEY,
     name VARCHAR(255) UNIQUE NOT NULL,
     project_name VARCHAR(255) NOT NULL,
-    last_prefetch_timestamp TIMESTAMP
+    last_fetch_timestamp TIMESTAMP,
+    last_request_timestamp TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS bgp_dumps (
@@ -12,5 +13,7 @@ CREATE TABLE IF NOT EXISTS bgp_dumps (
     dump_type SMALLINT NOT NULL,
     duration INTERVAL,
     timestamp TIMESTAMP NOT NULL,
+    first_fetch_timestamp TIMESTAMP,
+    last_fetch_timestamp TIMESTAMP,
     CONSTRAINT unique_bgp_dump UNIQUE (collector_name, url)
 );

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS bgp_dumps (
     dump_type SMALLINT NOT NULL,
     duration INTERVAL,
     timestamp TIMESTAMP NOT NULL,
-    first_fetch_timestamp TIMESTAMP NOT NULL DEFAULT GETDATE(),
-    last_fetch_timestamp TIMESTAMP NOT NULL DEFAULT GETDATE(),
+    first_fetch_timestamp TIMESTAMP DEFAULT NOT NULL GETDATE(),
+    last_fetch_timestamp TIMESTAMP DEFAULT NOT NULL GETDATE(),
     CONSTRAINT unique_bgp_dump UNIQUE (collector_name, url)
 );

--- a/scrape_collectors.go
+++ b/scrape_collectors.go
@@ -61,7 +61,9 @@ func UpdateCollectorsData(ctx context.Context, logger *logging.Logger, db *pgxpo
 			Int("collector_count", len(collectors)).
 			Msg("Found collectors for project")
 
-		if err := UpsertCollectors(ctx, logger, db, collectors); err != nil {
+		currentTime := time.Now().UTC().Unix()
+
+		if err := UpsertCollectors(ctx, logger, db, collectors, &currentTime); err != nil {
 			logger.Error().Err(err).Str("project", project.Name).Msg("Failed to upsert collectors")
 			continue
 		}
@@ -73,7 +75,7 @@ func UpdateCollectorsData(ctx context.Context, logger *logging.Logger, db *pgxpo
 			query := Query{
 				Collectors: []Collector{collector},
 				DumpType:   DumpTypeAny,
-				From:       time.Unix(0, 0), // Start from Unix epoch (1970-01-01)
+				From:       time.Unix(0, 0),             // Start from Unix epoch (1970-01-01)
 				Until:      time.Now().AddDate(0, 0, 1), // Until tomorrow (to ensure we get today's data)
 			}
 
@@ -91,7 +93,7 @@ func UpdateCollectorsData(ctx context.Context, logger *logging.Logger, db *pgxpo
 				Int("dumps_found", len(dumps)).
 				Msg("Found BGP dumps for collector")
 
-			if err := UpsertBGPDumps(ctx, logger, db, dumps); err != nil {
+			if err := UpsertBGPDumps(ctx, logger, db, dumps, &currentTime); err != nil {
 				logger.Error().
 					Err(err).
 					Str("collector", collector.Name).

--- a/scrape_collectors.go
+++ b/scrape_collectors.go
@@ -63,7 +63,7 @@ func UpdateCollectorsData(ctx context.Context, logger *logging.Logger, db *pgxpo
 
 		currentTime := time.Now().UTC().Unix()
 
-		if err := UpsertCollectors(ctx, logger, db, collectors, &currentTime); err != nil {
+		if err := UpsertCollectors(ctx, logger, db, collectors, &currentTime, true); err != nil {
 			logger.Error().Err(err).Str("project", project.Name).Msg("Failed to upsert collectors")
 			continue
 		}


### PR DESCRIPTION
Updating schema of collectors table to include timestamp which holds the last time at which prefetch of data on collector was done.

This is being done because we wish to know the time upto which we have url data for a given collector so that on next run, we can fetch new data from that timestamp onwards.

Added more fields based on discussion as per this link: https://www.notion.so/inetintel/Status-implementation-plans-a7970494684447b4960ab588dd987058 .

Note: Code couldn't be tested yet since env files were not available.

