### PR TITLE
Adding a new field to collectors table and moving scraping code into …

### DIFF
--- a/db.go
+++ b/db.go
@@ -6,11 +6,12 @@ import (
 	"time"
 
 	"github.com/alistairking/bgpfinder/internal/logging"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // UpsertCollectors inserts or updates collector records.
-func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, collectors []Collector, timestampField string) error {
+func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, collectors []Collector, dumptType DumpType, timestamp time.Time) error {
 	tx, err := db.Begin(ctx)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to begin transaction for UpsertCollectors")
@@ -19,21 +20,29 @@ func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.P
 	defer tx.Rollback(ctx)
 	// Define the SQL query
 
+	var timestampField string
 	var timestampValue string
 	var timestampCondition string
 
-	if strings.Contains(timestampField, ",") {
-		timestampValue = `CURRENT_TIMESTAMP, CURRENT_TIMESTAMP`
-		timestampCondition = `last_completed_crawl_time_ribs = EXCLUDED.last_completed_crawl_time_ribs,
-		last_completed_crawl_time_updates = EXCLUDED.last_completed_crawl_time_updates`
-	} else {
-		timestampValue = `CURRENT_TIMESTAMP`
+	switch dumptType {
+	case DumpTypeRib:
+		timestampField = `last_completed_crawl_time_ribs`
+		timestampValue = `$4`
 		timestampCondition = timestampField + ` = EXCLUDED.` + timestampField
+	case DumpTypeUpdates:
+		timestampField = `last_completed_crawl_time_updates`
+		timestampValue = `$4`
+		timestampCondition = timestampField + ` = EXCLUDED.` + timestampField
+	case DumpTypeAny:
+		timestampField = `last_completed_crawl_time_ribs, last_completed_crawl_time_updates`
+		timestampValue = `$4, $5`
+		timestampCondition = `last_completed_crawl_time_ribs = EXCLUDED.last_completed_crawl_time_ribs,
+			last_completed_crawl_time_updates = EXCLUDED.last_completed_crawl_time_updates`
 	}
 
 	stmt := `
-		INSERT INTO collectors (name, project_name, cdate, mdate, ` + timestampField + `, most_recent_file_timestamp)
-		VALUES ($1, $2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,` + timestampValue + `, COALESCE((SELECT max(timestamp) FROM bgp_dumps WHERE collector_name = $3), '1970-01-01 00:00:00'))
+		INSERT INTO collectors (name, project_name, cdate, mdate, most_recent_file_timestamp, ` + timestampField + `)
+		VALUES ($1, $2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, COALESCE((SELECT max(timestamp) FROM bgp_dumps WHERE collector_name = $3), '1970-01-01 00:00:00'), ` + timestampValue + `)
 		ON CONFLICT (name) DO UPDATE
 		SET project_name = EXCLUDED.project_name,
 			mdate = EXCLUDED.mdate,
@@ -43,7 +52,16 @@ func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.P
 	for _, c := range collectors {
 		logger.Debug().Str("collector", c.Name).Str("project", c.Project.Name).Msg("Executing upsert for collector")
 		collectorName := c.Name
-		ct, err := tx.Exec(ctx, stmt, collectorName, c.Project.Name, collectorName)
+
+		var ct pgconn.CommandTag
+		var err error
+
+		if dumptType == DumpTypeAny {
+			ct, err = tx.Exec(ctx, stmt, collectorName, c.Project.Name, collectorName, timestamp, timestamp)
+		} else {
+			ct, err = tx.Exec(ctx, stmt, collectorName, c.Project.Name, collectorName, timestamp)
+		}
+
 		if err != nil {
 			logger.Error().Err(err).Str("collector", c.Name).Msg("Failed to execute upsert")
 			return err

--- a/db.go
+++ b/db.go
@@ -10,7 +10,7 @@ import (
 )
 
 // UpsertCollectors inserts or updates collector records.
-func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, collectors []Collector, dumpType DumpType) error {
+func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, collectors []Collector, timestampField string) error {
 	tx, err := db.Begin(ctx)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to begin transaction for UpsertCollectors")
@@ -18,21 +18,32 @@ func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.P
 	}
 	defer tx.Rollback(ctx)
 	// Define the SQL query
+
+	var timestampValue string
+	var timestampCondition string
+
+	if strings.Contains(timestampField, ",") {
+		timestampValue = `CURRENT_TIMESTAMP, CURRENT_TIMESTAMP`
+		timestampCondition = `last_completed_crawl_time_ribs = EXCLUDED.last_completed_crawl_time_ribs,
+		last_completed_crawl_time_updates = EXCLUDED.last_completed_crawl_time_updates`
+	} else {
+		timestampValue = `CURRENT_TIMESTAMP`
+		timestampCondition = timestampField + ` = EXCLUDED.` + timestampField
+	}
+
 	stmt := `
-		INSERT INTO collectors (name, project_name, cdate, mdate, last_completed_crawl_time, most_recent_file_timestamp, last_completed_crawl_dump_type)
-		VALUES ($1, $2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, COALESCE((SELECT max(timestamp) FROM bgp_dumps WHERE collector_name = $3), '1970-01-01 00:00:00'), $4)
+		INSERT INTO collectors (name, project_name, cdate, mdate, ` + timestampField + `, most_recent_file_timestamp)
+		VALUES ($1, $2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,` + timestampValue + `, COALESCE((SELECT max(timestamp) FROM bgp_dumps WHERE collector_name = $3), '1970-01-01 00:00:00'))
 		ON CONFLICT (name) DO UPDATE
 		SET project_name = EXCLUDED.project_name,
 			mdate = EXCLUDED.mdate,
-			most_recent_file_timestamp = EXCLUDED.most_recent_file_timestamp,
-			last_completed_crawl_time = EXCLUDED.last_completed_crawl_time
-	`
+			most_recent_file_timestamp = EXCLUDED.most_recent_file_timestamp,` + timestampCondition
 
 	logger.Info().Int("collector_count", len(collectors)).Msg("Upserting collectors into DB")
 	for _, c := range collectors {
 		logger.Debug().Str("collector", c.Name).Str("project", c.Project.Name).Msg("Executing upsert for collector")
 		collectorName := c.Name
-		ct, err := tx.Exec(ctx, stmt, collectorName, c.Project.Name, collectorName, dumpType.String())
+		ct, err := tx.Exec(ctx, stmt, collectorName, c.Project.Name, collectorName)
 		if err != nil {
 			logger.Error().Err(err).Str("collector", c.Name).Msg("Failed to execute upsert")
 			return err

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -5,8 +5,8 @@ CREATE TABLE IF NOT EXISTS collectors (
     cdate TIMESTAMP NOT NULL DEFAULT NOW(),
     mdate TIMESTAMP NOT NULL DEFAULT NOW(),
     most_recent_file_timestamp TIMESTAMP NOT NULL DEFAULT NOW(),
-    last_completed_crawl_time TIMESTAMP NOT NULL DEFAULT NOW(),
-    last_completed_crawl_dump_type VARCHAR(10) NOT NULL
+    last_completed_crawl_time_ribs TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_completed_crawl_time_updates TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE IF NOT EXISTS bgp_dumps (

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS collectors (
     mdate TIMESTAMP NOT NULL DEFAULT NOW(),
     most_recent_file_timestamp TIMESTAMP NOT NULL DEFAULT NOW(),
     last_completed_crawl_time TIMESTAMP NOT NULL DEFAULT NOW(),
-    last_completed_crawl_dump_type VARCHAR(1) NOT NULL
+    last_completed_crawl_dump_type VARCHAR(10) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS bgp_dumps (

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -5,7 +5,8 @@ CREATE TABLE IF NOT EXISTS collectors (
     cdate TIMESTAMP NOT NULL DEFAULT NOW(),
     mdate TIMESTAMP NOT NULL DEFAULT NOW(),
     most_recent_file_timestamp TIMESTAMP NOT NULL DEFAULT NOW(),
-    last_completed_crawl_time TIMESTAMP NOT NULL DEFAULT NOW()
+    last_completed_crawl_time TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_completed_crawl_dump_type VARCHAR(1) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS bgp_dumps (

--- a/periodicscraper/periodic_scraper_per_collector.go
+++ b/periodicscraper/periodic_scraper_per_collector.go
@@ -41,7 +41,7 @@ func PeriodicScraper(ctx context.Context,
 
 	wg.Wait()
 
-	return bgpfinder.UpsertCollectors(ctx, logger, db, successfullyWrittenCollectors, getDumpTypeFromBool(isRibsData))
+	return bgpfinder.UpsertCollectors(ctx, logger, db, successfullyWrittenCollectors, getTimestampForDumpType(isRibsData))
 }
 
 // PeriodicScraper starts a goroutine that scraps the collectors for data.

--- a/periodicscraper/periodic_scraper_per_collector.go
+++ b/periodicscraper/periodic_scraper_per_collector.go
@@ -39,7 +39,7 @@ func PeriodicScraper(ctx context.Context,
 		}()
 	}
 
-	return bgpfinder.UpsertCollectors(ctx, logger, db, successfullyWrittenCollectors)
+	return bgpfinder.UpsertCollectors(ctx, logger, db, successfullyWrittenCollectors, getDumpTypeFromBool(isRibsData))
 }
 
 // PeriodicScraper starts a goroutine that scraps the collectors for data.
@@ -86,13 +86,7 @@ func getDumps(ctx context.Context,
 
 	logger.Info().Str("collector", collector.Name).Msg("Starting to scrape collector data")
 
-	var dumpType bgpfinder.DumpType
-
-	if isRibsData {
-		dumpType = bgpfinder.DumpTypeRib
-	} else {
-		dumpType = bgpfinder.DumpTypeUpdates
-	}
+	dumpType := getDumpTypeFromBool(isRibsData)
 
 	query := bgpfinder.Query{
 		Collectors: []bgpfinder.Collector{collector},

--- a/periodicscraper/periodic_scraper_per_collector.go
+++ b/periodicscraper/periodic_scraper_per_collector.go
@@ -41,7 +41,7 @@ func PeriodicScraper(ctx context.Context,
 
 	wg.Wait()
 
-	return bgpfinder.UpsertCollectors(ctx, logger, db, successfullyWrittenCollectors, getTimestampForDumpType(isRibsData))
+	return bgpfinder.UpsertCollectors(ctx, logger, db, successfullyWrittenCollectors, getDumpTypeFromBool(isRibsData), time.Now())
 }
 
 // PeriodicScraper starts a goroutine that scraps the collectors for data.

--- a/periodicscraper/start.go
+++ b/periodicscraper/start.go
@@ -85,7 +85,7 @@ func waitUntilTimestamp(targetTime time.Time) {
 
 func driver(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, project string, isRibs bool) {
 	logger.Info().Msgf("Starting periodic collectors data for %s isribs: %t", project, isRibs)
-	collectors, prevRuntimes, err := getCollectorsAndPrevRuntime(ctx, logger, db, project)
+	collectors, prevRuntimes, err := getCollectorsAndPrevRuntime(ctx, logger, db, project, isRibs)
 	if err != nil {
 		logger.Error().Err(err).Msgf("Failed to run db to collect data for %s isribs: %t data for collectors", project, isRibs)
 	} else {

--- a/periodicscraper/util.go
+++ b/periodicscraper/util.go
@@ -164,7 +164,7 @@ func getDumpTypeFromBool(isRibs bool) bgpfinder.DumpType {
 	var dumpType bgpfinder.DumpType
 
 	if isRibs {
-		dumpType = bgpfinder.DumpTypeAny
+		dumpType = bgpfinder.DumpTypeRib
 	} else {
 		dumpType = bgpfinder.DumpTypeUpdates
 	}

--- a/scrape_collectors.go
+++ b/scrape_collectors.go
@@ -61,7 +61,7 @@ func UpdateCollectorsData(ctx context.Context, logger *logging.Logger, db *pgxpo
 			Int("collector_count", len(collectors)).
 			Msg("Found collectors for project")
 
-		if err := UpsertCollectors(ctx, logger, db, collectors); err != nil {
+		if err := UpsertCollectors(ctx, logger, db, collectors, DumpTypeAny); err != nil {
 			logger.Error().Err(err).Str("project", project.Name).Msg("Failed to upsert collectors")
 			continue
 		}

--- a/scrape_collectors.go
+++ b/scrape_collectors.go
@@ -61,7 +61,7 @@ func UpdateCollectorsData(ctx context.Context, logger *logging.Logger, db *pgxpo
 			Int("collector_count", len(collectors)).
 			Msg("Found collectors for project")
 
-		if err := UpsertCollectors(ctx, logger, db, collectors, DumpTypeAny); err != nil {
+		if err := UpsertCollectors(ctx, logger, db, collectors, `last_completed_crawl_time_ribs, last_completed_crawl_time_updates`); err != nil {
 			logger.Error().Err(err).Str("project", project.Name).Msg("Failed to upsert collectors")
 			continue
 		}

--- a/scrape_collectors.go
+++ b/scrape_collectors.go
@@ -61,7 +61,7 @@ func UpdateCollectorsData(ctx context.Context, logger *logging.Logger, db *pgxpo
 			Int("collector_count", len(collectors)).
 			Msg("Found collectors for project")
 
-		if err := UpsertCollectors(ctx, logger, db, collectors, `last_completed_crawl_time_ribs, last_completed_crawl_time_updates`); err != nil {
+		if err := UpsertCollectors(ctx, logger, db, collectors, DumpTypeAny, time.Now()); err != nil {
 			logger.Error().Err(err).Str("project", project.Name).Msg("Failed to upsert collectors")
 			continue
 		}


### PR DESCRIPTION
Adding a new field to collectors table to track last_crawl_time based on dump type and moving scraping code into go-routines to maximise paralllelism.


##Testing

RIS logs (no RIS Updates data for the given collector):
```
bgpfinder_periodic_scraper  | 2025-05-04T04:55:30Z INF Reached target time: 2025-05-04 04:55:30.146792887 +0000 UTC m=+102.805820336
bgpfinder_periodic_scraper  | 2025-05-04T04:55:30Z INF Starting periodic collectors data for ris isribs: false
bgpfinder_periodic_scraper  | Collector: ripe, Last Completed Crawl Time: 2025-05-04 04:48:10.975866 +0000 UTC
bgpfinder_periodic_scraper  | 2025-05-04T04:55:30Z INF Run of db on ris isribs: false completed successfully
bgpfinder_periodic_scraper  | 2025-05-04T04:55:31Z INF Starting to scrape collector data collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:33Z ERR Finder.Find failed error="failed to scrape https://data.ris.ripe.net/ripe : Unexpected status code: 404 404 Not Found" collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:33Z INF Will retry scraping collectors after sleeping. collector=ripe retries left=4
bgpfinder_periodic_scraper  | 2025-05-04T04:55:33Z INF Starting to scrape collector data collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:34Z ERR Finder.Find failed error="failed to scrape https://data.ris.ripe.net/ripe : Unexpected status code: 404 404 Not Found" collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:34Z INF Will retry scraping collectors after sleeping. collector=ripe retries left=3
bgpfinder_periodic_scraper  | 2025-05-04T04:55:34Z INF Starting to scrape collector data collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:35Z ERR Finder.Find failed error="failed to scrape https://data.ris.ripe.net/ripe : Unexpected status code: 404 404 Not Found" collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:35Z INF Will retry scraping collectors after sleeping. collector=ripe retries left=2
bgpfinder_periodic_scraper  | 2025-05-04T04:55:35Z INF Starting to scrape collector data collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:36Z ERR Finder.Find failed error="failed to scrape https://data.ris.ripe.net/ripe : Unexpected status code: 404 404 Not Found" collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:36Z INF Will retry scraping collectors after sleeping. collector=ripe retries left=1
bgpfinder_periodic_scraper  | 2025-05-04T04:55:36Z INF Starting to scrape collector data collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:37Z ERR Finder.Find failed error="failed to scrape https://data.ris.ripe.net/ripe : Unexpected status code: 404 404 Not Found" collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:37Z ERR Failed to update collectors data on initial run error="failed to scrape https://data.ris.ripe.net/ripe : Unexpected status code: 404 404 Not Found"
bgpfinder_periodic_scraper  | 2025-05-04T04:55:37Z ERR Failed to upsert dumps error="failed to scrape https://data.ris.ripe.net/ripe : Unexpected status code: 404 404 Not Found" collector=ripe
bgpfinder_periodic_scraper  | 2025-05-04T04:55:37Z INF Upserting collectors into DB collector_count=0
bgpfinder_periodic_scraper  | 2025-05-04T04:55:37Z INF Transaction committed successfully for UpsertCollectors
bgpfinder_periodic_scraper  | 2025-05-04T04:55:37Z INF Run of periodic scraper ris isribs: false completed successfully
bgpfinder_periodic_scraper  | 2025-05-04T04:55:37Z INF Scraping runtime for project ris and isribs false is 7.076110545s
```

Routeviews logs:

```
bgpfinder_periodic_scraper  | 2025-05-04T05:00:30Z INF Reached target time: 2025-05-04 05:00:30.146785179 +0000 UTC m=+402.805812586
bgpfinder_periodic_scraper  | 2025-05-04T05:00:30Z INF Starting periodic collectors data for routeviews isribs: false
bgpfinder_periodic_scraper  | Collector: route-views.soxrs, Last Completed Crawl Time: 2025-05-04 04:31:39.208913 +0000 UTC
bgpfinder_periodic_scraper  | Collector: route-views.rio, Last Completed Crawl Time: 2025-05-04 04:31:39.208913 +0000 UTC
bgpfinder_periodic_scraper  | 2025-05-04T05:00:30Z INF Run of db on routeviews isribs: false completed successfully
bgpfinder_periodic_scraper  | 2025-05-04T05:00:30Z INF Reached target time: 2025-05-04 05:00:30.239406256 +0000 UTC m=+402.897741301
bgpfinder_periodic_scraper  | 2025-05-04T05:00:30Z INF Starting periodic collectors data for ris isribs: false
bgpfinder_periodic_scraper  | 2025-05-04T05:00:30Z INF Run of db on ris isribs: false completed successfully
bgpfinder_periodic_scraper  | Collector: ripe, Last Completed Crawl Time: 2025-05-04 04:48:10.975866 +0000 UTC
bgpfinder_periodic_scraper  | 2025-05-04T05:00:31Z INF Starting to scrape collector data collector=route-views.rio
bgpfinder_periodic_scraper  | 2025-05-04T05:00:31Z INF Starting to scrape collector data collector=route-views.soxrs
bgpfinder_periodic_scraper  | 2025-05-04T05:00:31Z INF Starting to scrape collector data collector=ripe
bgpfinder_periodic_scraper  | Scraping  https://archive.routeviews.org/route-views.rio/bgpdata/2025.05/UPDATES/
bgpfinder_periodic_scraper  | Scraping  https://archive.routeviews.org/route-views.soxrs/bgpdata/2025.05/UPDATES/
bgpfinder_periodic_scraper  | 2025-05-04T05:00:33Z INF Scraping completed successfully
bgpfinder_periodic_scraper  | 2025-05-04T05:00:33Z INF Upserting collectors into DB collector_count=2
bgpfinder_periodic_scraper  | 2025-05-04T05:00:33Z INF Transaction committed successfully for UpsertCollectors
bgpfinder_periodic_scraper  | 2025-05-04T05:00:33Z INF Run of periodic scraper routeviews isribs: false completed successfully
```

The changes to the tables in the DB are captured here:

https://docs.google.com/document/d/1Y0TcXYmQPYbcYI-Z2nZFUsDd2oUYpePBG1wbQRrJnpw/edit?tab=t.0