### PR TITLE
Fix outstanding pre-release issues

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -2,6 +2,10 @@
 
 This guide explains how to deploy the BGPFinder stack (API service, periodic scraper, and Postgres database) using Docker Compose.
 
+Note that the deployment model described here does not include any redundancy.
+Extending this to add redundancy (i.e. to support a public instance) is left
+as an exercise to the reader.
+
 ## Prerequisites
 - Docker and Docker Compose installed on the host machine.
 - Network access to RouteViews and RIS data archives.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,69 @@
+# Deployment Guide: BGPFinder Service
+
+This guide explains how to deploy the BGPFinder stack (API service, periodic scraper, and Postgres database) using Docker Compose.
+
+## Prerequisites
+- Docker and Docker Compose installed on the host machine.
+- Network access to RouteViews and RIS data archives.
+
+## Step 1: Configure Environment
+Copy the example environment file and customize it for your deployment:
+
+```bash
+cp example.env .env
+```
+
+Open `.env` and configure the following:
+- `POSTGRES_PASSWORD`: Set a secure password for the database.
+- `API_PORT`: The port you want the service to be accessible on (e.g., `80`).
+- `DB_DATA_PATH`: The location on your host where database files will be stored (e.g., `./pgdata`).
+
+## Step 2: Launch the Service
+Run the following command to build and start the containers in detached mode:
+
+```bash
+docker-compose up -d --build
+```
+
+### What happens during startup?
+1. **Database Initialization**: On the first run, Postgres will automatically execute all SQL scripts in the `migrations/` directory to create the schema and seed initial data.
+2. **Health Checks**: The API and Scraper services will wait until the database is healthy before starting.
+3. **Scraping**: The scraper will begin its first run according to the frequency configured in the application.
+
+## Step 3: Verify Deployment
+Check the status of the containers:
+
+```bash
+docker-compose ps
+```
+
+Test the API endpoint (assuming `API_PORT=8080`):
+
+```bash
+curl "http://localhost:8080/meta/projects?human=1"
+```
+
+## Management Commands
+
+### Viewing Logs
+To see logs from all services:
+```bash
+docker-compose logs -f
+```
+
+To see logs from just the scraper:
+```bash
+docker-compose logs -f scraper
+```
+
+### Stopping the Service
+```bash
+docker-compose down
+```
+
+### Updating
+To update the service after code changes:
+```bash
+git pull
+docker-compose up -d --build
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,37 @@
-# Use the official Golang image for building
-FROM golang:latest
+# --- Build Stage ---
+FROM golang:1.21-alpine AS builder
 
-# Set the working directory in the container
-WORKDIR /bgpfinder
+WORKDIR /app
 
-# Copy the entire project to the container
-COPY . .
+# Install build dependencies
+RUN apk add --no-cache git
 
-# Download dependencies based on go.mod and go.sum
+# Copy dependencies
+COPY go.mod go.sum ./
 RUN go mod download
 
-# Build the Go application (this assumes your app is located under cmd/bgpfinder-server)
-RUN cd cmd/bgpfinder-server && go build -o bgpfinder-server
-RUN cd /bgpfinder/cmd/periodicscraper && go build -o scraper
+# Copy source code
+COPY . .
 
-# Make the binary executable
-RUN chmod +x /bgpfinder/cmd/bgpfinder-server/bgpfinder-server
-RUN chmod +x /bgpfinder/cmd/periodicscraper/scraper
+# Build API server
+RUN go build -o /bgpfinder-server ./cmd/bgpfinder-server
 
-# Expose the port for the Go application
+# Build Scraper
+RUN go build -o /scraper ./cmd/periodicscraper
+
+# --- Run Stage ---
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates tzdata
+
+WORKDIR /app
+
+# Copy binaries from builder
+COPY --from=builder /bgpfinder-server .
+COPY --from=builder /scraper .
+
+# Expose the default internal port
 EXPOSE 8080
 
-# Set the default command to run the Go application
-CMD ["/bgpfinder/cmd/bgpfinder-server/bgpfinder-server", "--port=8080", "--use-db", "--env-file", "/bgpfinder/example.env"]
-CMD ["/bgpfinder/cmd/periodicscraper/scraper", "--env-file=/bgpfinder/example.env"]
+# Default command (can be overridden by docker-compose)
+CMD ["./bgpfinder-server"]

--- a/README.md
+++ b/README.md
@@ -1,56 +1,41 @@
-# bgpfinder
+# BGPFinder
 
-These are WIP notes about the bgpfinder project. Eventually this can be tidied up as user documentation.
+BGPFinder is a high-performance, database-backed indexer and broker for BGP data archives. It is designed to be a drop-in replacement for the [BGPStream Broker](https://bgpstream.caida.org/docs/api/broker) API. Users may use BGPFinder to host their own private or local brokers for BGP data, or they may query public BGPFinder instances hosted by other organizations.
 
-## Technology
+## Key Features
 
-- Language: Go. It's what I know best these days, and it's easy to do HTTP things with it.
-- DB: 
-  - I'm open to suggestions
-  - We don't need to pick just yet
-  - Maybe a combo of redis and postgres?
-  - Nothing newfangled.
-- Build & Deploy:
-  - Let's get Github Actions set up ASAP
-  - Use to run tests and build docker images
+*   **BGPStream Compatible**: Implements the BGPStream Broker API (v2), allowing standard BGPStream clients to interface with a BGPFinder service without modification.
+*   **Multi-Project Support**: Native support for indexing both **University of Oregon RouteViews** and **RIPE RIS** data archives. The code is designed to support the easy addition of other projects that archive BGP MRT files.
+*   **Persistent Indexing**: Uses a Postgres database to cache metadata about millions of BGP dumps, ensuring fast response times for common queries.
 
-## Packages
 
-### base package: finder (used as a library)
-- keep it simple. just support what we need. don’t make it too generic (hard coded stuff for a project is fine)
-- handle only http urls (deal with kafka etc elsewhere, if you want a local archive, do it with object storage)
-- defines Finder interface that other packages may implement
-- just hit website and do parsing. it’s up to the caller to figure out lengths etc
-- don’t worry much about edge cases where timestamps in files are off (leave it to the caller to ask for more time than they need if they care)
-- intervals are inclusive,exclusive
-  - e.g., midnight-1am returns 00,15,45 for rv collectors
-- simple CLI that enables testing while development as well as use in scripts
-  - e.g., find files matching a query and then pipe into xargs wget
+## Architecture
 
-#### Finder interface:
-- list of projects
-- list of collectors (ideally dynamic)
-  - (optionally) overall approx time range for collector
-- give me all the URLs for a project/collector/time window
+BGPFinder consists of three primary components:
 
-### next package: server
-- wrap finder in http server
-- backwards compat with bgpstream broker API
-- still no db. just fire up finder for every request
-- designed to be run as sidecar to bgpstream instance(s)
-- allows bgpstream to work without extra infra (or if broker infra goes down)
-- hopefully will make production use more appealing
+1.  **The Scraper**: A periodic daemon that crawls the RouteViews and RIPE RIS web archives to discover new BGP dumps as they are published.
+2.  **The Database**: A Postgres instance that stores the locations, timestamps, and metadata for every discovered BGP dump.
+3.  **The API Service**: A Go-based HTTP server that handles broker queries from BGPStream clients, performing optimized database searches to return matching dump URLs.
 
-### and then: cache/database
-- similar to current downloader
-- runs as daemon
-- uses finder package
-- periodically schedules finds across proj/coll/time
-  - schedule finds for recent windows regularly, less frequent for old windows
-- compares found URLs to DB, updates accordingly.
-- implements finder interface so that server and/or other embedded users can benefit from cache
+## Deployment
 
-### finally: public instance(s)
-- run finder server in several stable places
-- update bgpstream broker code to call finder server
-- all bgpstream features should work in this way
+Deployment is managed via Docker Compose, which handles the orchestration of the API service, the scraper, and the database.
+
+For detailed setup instructions, please see: **[DEPLOY.md](./DEPLOY.md)**
+
+## Acknowledgements
+
+### Authors
+BGPFinder was originally designed and implemented by **Alistair King**.
+
+Notable contributors include:
+*   **Shane Alcock**
+*   **Zachary Bischof**
+*   **Nahush H Kumta**
+*   **Xie Qiu**
+
+### Maintenance
+This project is currently maintained by the [Internet Intelligence Lab](https://inetintel.cc.gatech.edu/) at the Georgia Institute of Technology. Please file any bug reports as issues on the [BGPFinder GitHub page](https://github.com/inetintel/bgpfinder).
+
+## License
+BGPFinder is released under the BSD 2-Clause License. See [LICENSE](./LICENSE) for details.

--- a/alias_manager.go
+++ b/alias_manager.go
@@ -1,0 +1,69 @@
+package bgpfinder
+
+import (
+	"context"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var DefaultAliasManager *AliasManager
+
+type AliasManager struct {
+	mu      sync.RWMutex
+	aliases map[string]map[string]string // Project -> Alias -> Canonical
+}
+
+func NewAliasManager() *AliasManager {
+	return &AliasManager{
+		aliases: make(map[string]map[string]string),
+	}
+}
+
+func (m *AliasManager) Reload(ctx context.Context, db *pgxpool.Pool) error {
+	newAliases, err := FetchCollectorAliases(ctx, db)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.aliases = newAliases
+	return nil
+}
+
+func (m *AliasManager) GetAliases(project string) map[string]string {
+	if m == nil {
+		return make(map[string]string)
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if project == "" {
+		// Aggregate all aliases if no project specified
+		all := make(map[string]string)
+		for _, projAliases := range m.aliases {
+			for alias, canonical := range projAliases {
+				all[alias] = canonical
+			}
+		}
+		return all
+	}
+
+	// Return a copy to avoid external mutation
+	original := m.aliases[project]
+	if original == nil {
+		return make(map[string]string)
+	}
+	res := make(map[string]string, len(original))
+	for k, v := range original {
+		res[k] = v
+	}
+	return res
+}
+
+func GetCollectorNameAliases(project string) (map[string]string, error) {
+	if DefaultAliasManager == nil {
+		return make(map[string]string), nil
+	}
+	return DefaultAliasManager.GetAliases(project), nil
+}

--- a/base_finder.go
+++ b/base_finder.go
@@ -1,0 +1,72 @@
+package bgpfinder
+
+import (
+	"fmt"
+	"sync"
+)
+
+// BaseFinder provides a common implementation for caching collectors.
+// Other finders can embed this to reduce boilerplate.
+type BaseFinder struct {
+	mu            sync.RWMutex
+	collectors    []Collector
+	collectorsErr error
+	project       Project
+	
+	// getCollectorsFunc is the project-specific logic to fetch collectors
+	getCollectorsFunc func() ([]Collector, error)
+}
+
+func (f *BaseFinder) Init(project Project, getCollectorsFunc func() ([]Collector, error)) {
+	f.project = project
+	f.getCollectorsFunc = getCollectorsFunc
+}
+
+func (f *BaseFinder) Projects() ([]Project, error) {
+	return []Project{f.project}, nil
+}
+
+func (f *BaseFinder) Project(name string) (Project, error) {
+	if name == "" || name == f.project.Name {
+		return f.project, nil
+	}
+	return Project{}, nil
+}
+
+func (f *BaseFinder) Collectors(project string) ([]Collector, error) {
+	if project != "" && project != f.project.Name {
+		return nil, nil
+	}
+	if err := f.ensureCollectors(); err != nil {
+		return nil, err
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.collectors, f.collectorsErr
+}
+
+func (f *BaseFinder) Collector(name string) (Collector, error) {
+	if err := f.ensureCollectors(); err != nil {
+		return Collector{}, err
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for _, c := range f.collectors {
+		if c.Name == name {
+			return c, nil
+		}
+	}
+	return Collector{}, fmt.Errorf("collector not found: %s", name)
+}
+
+func (f *BaseFinder) ensureCollectors() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.collectors != nil || f.collectorsErr != nil {
+		return f.collectorsErr
+	}
+	c, err := f.getCollectorsFunc()
+	f.collectors = c
+	f.collectorsErr = err
+	return err
+}

--- a/cmd/bgpfinder-server/main.go
+++ b/cmd/bgpfinder-server/main.go
@@ -92,6 +92,30 @@ func main() {
 		}
 		defer db.Close()
 		logger.Info().Msg("Successfully connected to Database")
+
+		// Initialize Collector Alias Manager
+		bgpfinder.DefaultAliasManager = bgpfinder.NewAliasManager()
+		if err := bgpfinder.DefaultAliasManager.Reload(context.Background(), db); err != nil {
+			logger.Error().Err(err).Msg("Failed to perform initial load of collector aliases")
+		} else {
+			logger.Info().Msg("Successfully loaded collector aliases from database")
+		}
+
+		// Start background alias reloader (every hour)
+		go func() {
+			ticker := time.NewTicker(time.Hour)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					if err := bgpfinder.DefaultAliasManager.Reload(context.Background(), db); err != nil {
+						logger.Error().Err(err).Msg("Failed to reload collector aliases from database")
+					} else {
+						logger.Debug().Msg("Successfully reloaded collector aliases from database")
+					}
+				}
+			}
+		}()
 	}
 
 	// Set up context to handle signals for graceful shutdown

--- a/cmd/bgpfinder-server/main.go
+++ b/cmd/bgpfinder-server/main.go
@@ -32,8 +32,10 @@ type DBConfig struct {
 }
 
 func loadDBConfig(envFile string) (*DBConfig, error) {
-	if err := godotenv.Load(envFile); err != nil {
-		return nil, fmt.Errorf("error loading env file: %w", err)
+	if _, err := os.Stat(envFile); err == nil {
+		if err := godotenv.Load(envFile); err != nil {
+			return nil, fmt.Errorf("error loading env file: %w", err)
+		}
 	}
 
 	config := &DBConfig{

--- a/cmd/bgpfinder-server/main.go
+++ b/cmd/bgpfinder-server/main.go
@@ -477,13 +477,28 @@ func parseDataRequest(r *http.Request) (bgpfinder.Query, error) {
 		query.MinInitialTime = &ts
 	}
 
-	if dataAddedSince != "" {
-		dataAddedSinceInt, err := strconv.ParseInt(dataAddedSince, 10, 64)
-		if err != nil {
-			return query, fmt.Errorf("invalid dataAddedSince: %v", err)
+	// Check if any interval has a specific until (not 0)
+	hasSpecificUntil := false
+	for _, interval := range query.Intervals {
+		if interval.Until.Unix() != 0 {
+			hasSpecificUntil = true
+			break
 		}
-		ts := time.Unix(dataAddedSinceInt, 0)
-		query.DataAddedSince = &ts
+	}
+
+	if dataAddedSince != "" {
+		if hasSpecificUntil {
+			// libbgpstream has a bug where it includes dataAddedSince in all follow-up
+			// requests for historical data once paginated. We replicate the CAIDA
+			// broker behavior here by ignoring it if an 'until' time is set.
+		} else {
+			dataAddedSinceInt, err := strconv.ParseInt(dataAddedSince, 10, 64)
+			if err != nil {
+				return query, fmt.Errorf("invalid dataAddedSince: %v", err)
+			}
+			ts := time.Unix(dataAddedSinceInt, 0)
+			query.DataAddedSince = &ts
+		}
 	}
 
 	var collectors []bgpfinder.Collector
@@ -639,6 +654,9 @@ func dataHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc {
 
 		if query.MinInitialTime != nil {
 			evt.Time("minInitialTime", query.MinInitialTime.UTC())
+		}
+		if r.URL.Query().Get("dataAddedSince") != "" && query.DataAddedSince == nil {
+			evt.Bool("dataAddedSince_ignored", true)
 		}
 		evt.Msg("Parsed query parameters")
 

--- a/cmd/bgpfinder-server/main.go
+++ b/cmd/bgpfinder-server/main.go
@@ -255,6 +255,11 @@ type ResponseCollector struct {
 	LatestUpdatesDump string
 }
 
+func parseHumanParam(r *http.Request) bool {
+	human := r.URL.Query().Get("human")
+	return human == "1" || human == "true"
+}
+
 // projectHandler handles /meta/projects and /meta/projects/{project} endpoints
 func projectHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -312,11 +317,10 @@ func projectHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc {
 			}
 		}
 
-		queryMap := map[string]interface{}{"human": false}
+		queryMap := map[string]interface{}{"human": parseHumanParam(r)}
 		if projectName != "" {
 			queryMap["project"] = projectName
 		}
-
 		projectsResponse := ProjectsResponse{
 			Query:        queryMap,
 			DataProjects: DataProjects{projectsMap},
@@ -325,7 +329,7 @@ func projectHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc {
 			Type:         "meta",
 			Error:        nil,
 		}
-		jsonResponse(w, projectsResponse)
+		jsonResponse(w, projectsResponse, parseHumanParam(r))
 	}
 }
 
@@ -375,7 +379,7 @@ func collectorHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc
 			}
 		}
 
-		queryMap := map[string]interface{}{"human": false}
+		queryMap := map[string]interface{}{"human": parseHumanParam(r)}
 		if collectorName != "" {
 			queryMap["collector"] = collectorName
 		}
@@ -391,18 +395,18 @@ func collectorHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc
 
 		if collectorName == "" {
 			// Return all collectors
-			jsonResponse(w, collectorsResponse)
+			jsonResponse(w, collectorsResponse, parseHumanParam(r))
 		} else {
 			// Return specific collector if exists
 			if collector, exists := collectorsMap[collectorName]; exists {
 				collectorsResponse.DataProjects.Collectors = map[string]ResponseCollector{collectorName: collector}
-				jsonResponse(w, collectorsResponse)
+				jsonResponse(w, collectorsResponse, parseHumanParam(r))
 				return
 			} else if alias, avail := aliases[collectorName]; avail {
 				if alias != "" {
 					if col, repl := collectorsMap[alias]; repl {
 						collectorsResponse.DataProjects.Collectors = map[string]ResponseCollector{alias: col}
-						jsonResponse(w, collectorsResponse)
+						jsonResponse(w, collectorsResponse, parseHumanParam(r))
 						return
 					}
 				}
@@ -434,6 +438,7 @@ func parseDataRequest(r *http.Request) (bgpfinder.Query, error) {
 	collectorParam := queryParams.Get("collector")
 	minInitialTime := queryParams.Get("minInitialTime")
 	dataAddedSince := queryParams.Get("dataAddedSince")
+	query.Human = parseHumanParam(r)
 
 	// Parse intervals
 	if len(intervalsParams) == 0 {
@@ -718,12 +723,23 @@ func dataHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc {
 }
 
 // jsonResponse sends a JSON response
-func jsonResponse(w http.ResponseWriter, data interface{}) {
+func jsonResponse(w http.ResponseWriter, data interface{}, human bool) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		http.Error(w, fmt.Sprintf("Error encoding JSON: %v", err), http.StatusInternalServerError)
+
+	var b []byte
+	var err error
+	if human {
+		b, err = json.MarshalIndent(data, "", "  ")
+	} else {
+		b, err = json.Marshal(data)
 	}
+
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error encoding JSON: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Write(b)
 }
 
 func populateDataResponse(w http.ResponseWriter, data Data,
@@ -736,5 +752,5 @@ func populateDataResponse(w http.ResponseWriter, data Data,
 		Type:    "data",
 		Error:   nil,
 	}
-	jsonResponse(w, dataResp)
+	jsonResponse(w, dataResp, query.Human)
 }

--- a/cmd/bgpfinder-server/main.go
+++ b/cmd/bgpfinder-server/main.go
@@ -29,6 +29,7 @@ type DBConfig struct {
 	User     string
 	Password string
 	DBName   string
+	DSN      string
 }
 
 func loadDBConfig(envFile string) (*DBConfig, error) {
@@ -38,17 +39,25 @@ func loadDBConfig(envFile string) (*DBConfig, error) {
 		}
 	}
 
+	dsn := os.Getenv("POSTGRES_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_URL")
+	}
+
 	config := &DBConfig{
 		Host:     os.Getenv("POSTGRES_HOST"),
 		Port:     os.Getenv("POSTGRES_PORT"),
 		User:     os.Getenv("POSTGRES_USER"),
 		Password: os.Getenv("POSTGRES_PASSWORD"),
 		DBName:   os.Getenv("POSTGRES_DB"),
+		DSN:      dsn,
 	}
 
-	// Validate required fields
-	if config.User == "" || config.Password == "" || config.DBName == "" {
-		return nil, fmt.Errorf("missing required database configuration")
+	// Validate required fields only if DSN is not provided
+	if config.DSN == "" {
+		if config.User == "" || config.Password == "" || config.DBName == "" {
+			return nil, fmt.Errorf("missing required database configuration")
+		}
 	}
 
 	return config, nil
@@ -79,14 +88,22 @@ func main() {
 			logger.Fatal().Err(err).Msg("Failed to load database configuration")
 		}
 
-		connStr := fmt.Sprintf(
-			"postgres://%s:%s@%s:%s/%s?sslmode=disable",
-			config.User,
-			config.Password,
-			config.Host,
-			config.Port,
-			config.DBName,
-		)
+		var connStr string
+		if config.DSN != "" {
+			connStr = config.DSN
+		} else {
+			hostPart := config.Host
+			if config.Port != "" && !strings.Contains(config.Host, ":") {
+				hostPart = fmt.Sprintf("%s:%s", config.Host, config.Port)
+			}
+			connStr = fmt.Sprintf(
+				"postgres://%s:%s@%s/%s?sslmode=disable",
+				config.User,
+				config.Password,
+				hostPart,
+				config.DBName,
+			)
+		}
 
 		db, err = pgxpool.New(context.Background(), connStr)
 		if err != nil {

--- a/cmd/bgpfinder-server/main.go
+++ b/cmd/bgpfinder-server/main.go
@@ -576,12 +576,34 @@ func parseDataRequest(r *http.Request) (bgpfinder.Query, error) {
 	if len(typesParams) == 0 {
 		query.DumpType = bgpfinder.DumpTypeAny
 	} else {
-		// Use the first type parameter
-		dumpType, err := bgpfinder.DumpTypeString(typesParams[0])
-		if err != nil {
-			return query, fmt.Errorf("invalid type: %s", typesParams[0])
+		query.RequestedTypes = typesParams
+		hasRibs := false
+		hasUpdates := false
+		
+		for _, t := range typesParams {
+			dumpType, err := bgpfinder.DumpTypeString(t)
+			if err != nil {
+				return query, fmt.Errorf("invalid type: %s", t)
+			}
+			if dumpType == bgpfinder.DumpTypeRibs {
+				hasRibs = true
+			} else if dumpType == bgpfinder.DumpTypeUpdates {
+				hasUpdates = true
+			} else if dumpType == bgpfinder.DumpTypeAny {
+				hasRibs = true
+				hasUpdates = true
+			}
 		}
-		query.DumpType = dumpType
+
+		if hasRibs && hasUpdates {
+			query.DumpType = bgpfinder.DumpTypeAny
+		} else if hasRibs {
+			query.DumpType = bgpfinder.DumpTypeRibs
+		} else if hasUpdates {
+			query.DumpType = bgpfinder.DumpTypeUpdates
+		} else {
+			query.DumpType = bgpfinder.DumpTypeAny
+		}
 	}
 
 	return query, nil

--- a/cmd/bgpfinder-server/main.go
+++ b/cmd/bgpfinder-server/main.go
@@ -175,9 +175,8 @@ type ProjectsResponse struct {
 	Time         int64           `json:"time,omitempty"`
 	Type         string          `json:"type,omitempty"`
 	Error        *string         `json:"error"`
-	Query        bgpfinder.Query `json:"queryParameters"`
+	Query        interface{}     `json:"queryParameters"`
 	DataProjects DataProjects    `json:"data"`
-	// QueryParameters QueryParameters `json:"queryParameters"`
 }
 
 type DataCollectors struct {
@@ -189,9 +188,8 @@ type CollectorsResponse struct {
 	Time         int64           `json:"time,omitempty"`
 	Type         string          `json:"type,omitempty"`
 	Error        *string         `json:"error"`
-	Query        bgpfinder.Query `json:"queryParameters"`
+	Query        interface{}     `json:"queryParameters"`
 	DataProjects DataCollectors  `json:"data"`
-	// QueryParameters QueryParameters `json:"queryParameters"`
 }
 
 type DataType struct {
@@ -314,12 +312,17 @@ func projectHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc {
 			}
 		}
 
+		queryMap := map[string]interface{}{"human": false}
+		if projectName != "" {
+			queryMap["project"] = projectName
+		}
+
 		projectsResponse := ProjectsResponse{
-			Query:        bgpfinder.Query{},
+			Query:        queryMap,
 			DataProjects: DataProjects{projectsMap},
 			Time:         time.Now().Unix(),
 			Version:      "2",
-			Type:         "data",
+			Type:         "meta",
 			Error:        nil,
 		}
 		jsonResponse(w, projectsResponse)
@@ -372,12 +375,17 @@ func collectorHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc
 			}
 		}
 
+		queryMap := map[string]interface{}{"human": false}
+		if collectorName != "" {
+			queryMap["collector"] = collectorName
+		}
+
 		collectorsResponse := CollectorsResponse{
-			Query:        bgpfinder.Query{},
+			Query:        queryMap,
 			DataProjects: DataCollectors{collectorsMap},
 			Time:         time.Now().Unix(),
 			Version:      "2",
-			Type:         "data",
+			Type:         "meta",
 			Error:        nil,
 		}
 
@@ -387,12 +395,14 @@ func collectorHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc
 		} else {
 			// Return specific collector if exists
 			if collector, exists := collectorsMap[collectorName]; exists {
-				jsonResponse(w, collector)
+				collectorsResponse.DataProjects.Collectors = map[string]ResponseCollector{collectorName: collector}
+				jsonResponse(w, collectorsResponse)
 				return
 			} else if alias, avail := aliases[collectorName]; avail {
 				if alias != "" {
 					if col, repl := collectorsMap[alias]; repl {
-						jsonResponse(w, col)
+						collectorsResponse.DataProjects.Collectors = map[string]ResponseCollector{alias: col}
+						jsonResponse(w, collectorsResponse)
 						return
 					}
 				}

--- a/cmd/bgpfinder-server/main.go
+++ b/cmd/bgpfinder-server/main.go
@@ -762,6 +762,10 @@ func dataHandler(db *pgxpool.Pool, logger *logging.Logger) http.HandlerFunc {
 		if results == nil {
 			results = []bgpfinder.BGPDump{}
 		}
+
+		// Apply pagination capping only for API responses
+		results = bgpfinder.ApplyResultCap(results)
+
 		populateDataResponse(w, Data{results}, query)
 	}
 }

--- a/db.go
+++ b/db.go
@@ -430,3 +430,25 @@ func parseInterval(val interface{}) time.Duration {
 	}
 	return 0
 }
+
+func FetchCollectorAliases(ctx context.Context, db *pgxpool.Pool) (map[string]map[string]string, error) {
+	sql := "SELECT project, alias, canonical_name FROM collector_aliases"
+	rows, err := db.Query(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	results := make(map[string]map[string]string)
+	for rows.Next() {
+		var project, alias, canonical string
+		if err := rows.Scan(&project, &alias, &canonical); err != nil {
+			return nil, err
+		}
+		if results[project] == nil {
+			results[project] = make(map[string]string)
+		}
+		results[project][alias] = canonical
+	}
+	return results, nil
+}

--- a/db.go
+++ b/db.go
@@ -30,16 +30,16 @@ func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.P
 	case DumpTypeRibs:
 		timestampField = `last_completed_crawl_time_ribs`
 		timestampValue = `$4`
-		timestampCondition = timestampField + ` = GREATEST(` + timestampField + `, EXCLUDED.` + timestampField + `)`
+		timestampCondition = timestampField + ` = GREATEST(collectors.` + timestampField + `, EXCLUDED.` + timestampField + `)`
 	case DumpTypeUpdates:
 		timestampField = `last_completed_crawl_time_updates`
 		timestampValue = `$4`
-		timestampCondition = timestampField + ` = GREATEST(` + timestampField + `, EXCLUDED.` + timestampField + `)`
+		timestampCondition = timestampField + ` = GREATEST(collectors.` + timestampField + `, EXCLUDED.` + timestampField + `)`
 	case DumpTypeAny:
 		timestampField = `last_completed_crawl_time_ribs, last_completed_crawl_time_updates`
 		timestampValue = `$4, $5`
-		timestampCondition = `last_completed_crawl_time_ribs = GREATEST(last_completed_crawl_time_ribs, EXCLUDED.last_completed_crawl_time_ribs),
-			last_completed_crawl_time_updates = GREATEST(last_completed_crawl_time_updates, EXCLUDED.last_completed_crawl_time_updates)`
+		timestampCondition = `last_completed_crawl_time_ribs = GREATEST(collectors.last_completed_crawl_time_ribs, EXCLUDED.last_completed_crawl_time_ribs),
+			last_completed_crawl_time_updates = GREATEST(collectors.last_completed_crawl_time_updates, EXCLUDED.last_completed_crawl_time_updates)`
 	}
 
 	stmt := `

--- a/db.go
+++ b/db.go
@@ -30,16 +30,16 @@ func UpsertCollectors(ctx context.Context, logger *logging.Logger, db *pgxpool.P
 	case DumpTypeRibs:
 		timestampField = `last_completed_crawl_time_ribs`
 		timestampValue = `$4`
-		timestampCondition = timestampField + ` = EXCLUDED.` + timestampField
+		timestampCondition = timestampField + ` = GREATEST(` + timestampField + `, EXCLUDED.` + timestampField + `)`
 	case DumpTypeUpdates:
 		timestampField = `last_completed_crawl_time_updates`
 		timestampValue = `$4`
-		timestampCondition = timestampField + ` = EXCLUDED.` + timestampField
+		timestampCondition = timestampField + ` = GREATEST(` + timestampField + `, EXCLUDED.` + timestampField + `)`
 	case DumpTypeAny:
 		timestampField = `last_completed_crawl_time_ribs, last_completed_crawl_time_updates`
 		timestampValue = `$4, $5`
-		timestampCondition = `last_completed_crawl_time_ribs = EXCLUDED.last_completed_crawl_time_ribs,
-			last_completed_crawl_time_updates = EXCLUDED.last_completed_crawl_time_updates`
+		timestampCondition = `last_completed_crawl_time_ribs = GREATEST(last_completed_crawl_time_ribs, EXCLUDED.last_completed_crawl_time_ribs),
+			last_completed_crawl_time_updates = GREATEST(last_completed_crawl_time_updates, EXCLUDED.last_completed_crawl_time_updates)`
 	}
 
 	stmt := `

--- a/default_finder.go
+++ b/default_finder.go
@@ -34,9 +34,6 @@ func GetCollector(name string) (Collector, error) {
 	return DefaultFinder.Collector(name)
 }
 
-func GetCollectorNameAliases(project string) (map[string]string, error) {
-	return DefaultFinder.GetCollectorNameAliases(project)
-}
 
 func Find(query Query) ([]BGPDump, error) {
 	return DefaultFinder.Find(query)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:15-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,7 @@ services:
     env_file:
       - .env
     environment:
-      - POSTGRES_HOST=db
-      - POSTGRES_PORT=5432
+      - POSTGRES_HOST=db:5432
     command: ["./bgpfinder-server", "--port=${CONTAINER_PORT:-8080}", "--use-db"]
 
   scraper:
@@ -42,6 +41,5 @@ services:
     env_file:
       - .env
     environment:
-      - POSTGRES_HOST=db
-      - POSTGRES_PORT=5432
+      - POSTGRES_HOST=db:5432
     command: ["./scraper"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,43 +1,51 @@
+version: '3.8'
+
 services:
   db:
-    image: postgres:15
-    ports:
-      - "5432:5432"
+    image: postgres:15-alpine
     container_name: bgpfinder_db
     restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-bgpfinder}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-bgpfinder}
     volumes:
+      - ${DB_DATA_PATH:-./pgdata}:/var/lib/postgresql/data
       - ./migrations:/docker-entrypoint-initdb.d
-    environment:
-      POSTGRES_USER: myuser
-      POSTGRES_PASSWORD: mypass
-      POSTGRES_DB: bgpfinder_db
-  bgpfinder:
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-bgpfinder} -d ${POSTGRES_DB:-bgpfinder}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  api:
     build: .
-    container_name: bgpfinder_app
+    container_name: bgpfinder_api
+    restart: always
     depends_on:
-      - db
-    environment:
-      POSTGRES_USER: myuser
-      POSTGRES_PASSWORD: mypass
-      POSTGRES_DB: bgpfinder_db
-      POSTGRES_PORT: "5432"
-      POSTGRES_HOST: db
-    env_file:
-      - example.env
+      db:
+        condition: service_healthy
     ports:
-      - "8080:8080"
-    command: ["./cmd/bgpfinder-server/bgpfinder-server", "--port=8080", "--use-db", "--env-file=/bgpfinder/example.env"]
-  periodic_scraper:
-    build: .
-    container_name: bgpfinder_periodic_scraper
-    depends_on:
-      - db
+      - "${API_PORT:-8080}:${CONTAINER_PORT:-8080}"
     environment:
-      POSTGRES_USER: myuser
-      POSTGRES_PASSWORD: mypass
-      POSTGRES_DB: bgpfinder_db
-      POSTGRES_PORT: "5432"
-      POSTGRES_HOST: db
-    env_file:
-      - example.env
-    command: ["./cmd/periodicscraper/scraper", "--env-file=/bgpfinder/example.env"]
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_HOST=db
+      - POSTGRES_PORT=5432
+    command: ["./bgpfinder-server", "--port=${CONTAINER_PORT:-8080}", "--use-db"]
+
+  scraper:
+    build: .
+    container_name: bgpfinder_scraper
+    restart: always
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_HOST=db
+      - POSTGRES_PORT=5432
+    command: ["./scraper"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,10 +27,9 @@ services:
         condition: service_healthy
     ports:
       - "${API_PORT:-8080}:${CONTAINER_PORT:-8080}"
+    env_file:
+      - .env
     environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_HOST=db
       - POSTGRES_PORT=5432
     command: ["./bgpfinder-server", "--port=${CONTAINER_PORT:-8080}", "--use-db"]
@@ -42,10 +41,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    env_file:
+      - .env
     environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_HOST=db
       - POSTGRES_PORT=5432
     command: ["./scraper"]

--- a/example.env
+++ b/example.env
@@ -3,3 +3,5 @@ POSTGRES_PASSWORD=mypass
 POSTGRES_DB=bgpfinder_db
 POSTGRES_PORT=5432
 ROUTEVIEWS_ARCHIVE_URL=https://archive.routeviews.org/
+RIS_COLLECTORS_URL=https://ris.ripe.net/docs/route-collectors/
+RIS_DATA_URL=https://data.ris.ripe.net/

--- a/example.env
+++ b/example.env
@@ -2,8 +2,8 @@
 POSTGRES_USER=bgpfinder
 POSTGRES_PASSWORD=change_me_immediately
 POSTGRES_DB=bgpfinder
-POSTGRES_HOST=db
-POSTGRES_PORT=5432
+# Can be a single host (e.g. db:5432), multi-host (e.g. h1:5432,h2:5433), or you can use POSTGRES_DSN
+POSTGRES_HOST=db:5432
 
 # --- API Service Configuration ---
 # The port the API service will listen on inside the container

--- a/example.env
+++ b/example.env
@@ -1,7 +1,21 @@
-POSTGRES_USER=myuser
-POSTGRES_PASSWORD=mypass
-POSTGRES_DB=bgpfinder_db
+# --- Database Configuration ---
+POSTGRES_USER=bgpfinder
+POSTGRES_PASSWORD=change_me_immediately
+POSTGRES_DB=bgpfinder
+POSTGRES_HOST=db
 POSTGRES_PORT=5432
-ROUTEVIEWS_ARCHIVE_URL=https://archive.routeviews.org/
-RIS_COLLECTORS_URL=https://ris.ripe.net/docs/route-collectors/
-RIS_DATA_URL=https://data.ris.ripe.net/
+
+# --- API Service Configuration ---
+# The port the API service will listen on inside the container
+CONTAINER_PORT=8080
+# The port the API service will be accessible on from the host
+API_PORT=8080
+
+# --- Persistence ---
+# Local directory on the host to store the database data
+DB_DATA_PATH=./pgdata
+
+# --- Scraper Configuration ---
+# Optional: Override archive URLs
+# ROUTEVIEWS_ARCHIVE_URL=http://archive.routeviews.org
+# RIS_DATA_URL=https://data.ris.ripe.net

--- a/example.env
+++ b/example.env
@@ -2,3 +2,4 @@ POSTGRES_USER=myuser
 POSTGRES_PASSWORD=mypass
 POSTGRES_DB=bgpfinder_db
 POSTGRES_PORT=5432
+ROUTEVIEWS_ARCHIVE_URL=https://archive.routeviews.org/

--- a/finder.go
+++ b/finder.go
@@ -79,8 +79,18 @@ type Finder interface {
 }
 
 func (d BGPDump) MarshalJSON() ([]byte, error) {
+	url := d.URL
+	if idx := strings.Index(url, "://"); idx != -1 {
+		scheme := url[:idx+3]
+		path := url[idx+3:]
+		for strings.Contains(path, "//") {
+			path = strings.ReplaceAll(path, "//", "/")
+		}
+		url = scheme + path
+	}
+
 	custom := map[string]interface{}{
-		"url":         d.URL,
+		"url":         url,
 		"format":      "mrt",  // TODO temporarily hardcoding, may need to fix
 		"transport":   "file", // TODO temporarily hardcoding, may need to fix
 		"project":     d.Project,

--- a/finder.go
+++ b/finder.go
@@ -203,6 +203,10 @@ func (q Query) MarshalJSON() ([]byte, error) {
 	} else {
 		custom["type"] = nil
 	}
+
+	if q.DataAddedSince != nil {
+		custom["dataAddedSince"] = q.DataAddedSince.Unix()
+	}
 	return json.Marshal(custom)
 }
 

--- a/finder.go
+++ b/finder.go
@@ -10,6 +10,16 @@ import (
 	"time"
 )
 
+const (
+	ProjectRIS        = "ris"
+	ProjectRouteViews = "routeviews"
+)
+
+var (
+	RisProject        = Project{Name: ProjectRIS}
+	RouteviewsProject = Project{Name: ProjectRouteViews}
+)
+
 var (
 	// TargetLimit is the preferred maximum number of results to return.
 	// Can be overridden by BGPFINDER_TARGET_LIMIT env var.

--- a/finder.go
+++ b/finder.go
@@ -139,6 +139,9 @@ type Query struct {
 	// Projects to search for. All projects if empty or unset
 	Projects []string
 
+	// The exact dump types strings requested
+	RequestedTypes []string
+
 	// Min initial time
 	MinInitialTime *time.Time
 
@@ -177,7 +180,11 @@ func (q Query) MarshalJSON() ([]byte, error) {
 	}
 	custom["collectors"] = collectorNames
 
-	custom["types"] = []string{q.DumpType.String()}
+	if len(q.RequestedTypes) > 0 {
+		custom["types"] = q.RequestedTypes
+	} else {
+		custom["types"] = []string{q.DumpType.String()}
+	}
 	if q.DumpType != DumpTypeAny {
 		custom["type"] = q.DumpType.String()
 	} else {

--- a/finder.go
+++ b/finder.go
@@ -152,6 +152,9 @@ type Query struct {
 	// The exact dump types strings requested
 	RequestedTypes []string
 
+	// Whether to return human-readable (pretty-printed) JSON
+	Human bool
+
 	// Min initial time
 	MinInitialTime *time.Time
 
@@ -182,7 +185,7 @@ func (q Query) MarshalJSON() ([]byte, error) {
 		custom["intervals"] = intervals
 	}
 
-	custom["human"] = false
+	custom["human"] = q.Human
 	custom["projects"] = q.Projects
 	collectorNames := make([]string, len(q.Collectors))
 	for i, c := range q.Collectors {

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -3,9 +3,9 @@ CREATE TABLE IF NOT EXISTS collectors (
     project_name VARCHAR(255) NOT NULL,
     cdate TIMESTAMP NOT NULL DEFAULT NOW(),
     mdate TIMESTAMP NOT NULL DEFAULT NOW(),
-    most_recent_file_timestamp TIMESTAMP NOT NULL DEFAULT NOW(),
-    last_completed_crawl_time_ribs TIMESTAMP NOT NULL DEFAULT NOW(),
-    last_completed_crawl_time_updates TIMESTAMP NOT NULL DEFAULT NOW()
+    most_recent_file_timestamp TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00',
+    last_completed_crawl_time_ribs TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00',
+    last_completed_crawl_time_updates TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00'
 );
 
 CREATE TABLE IF NOT EXISTS bgp_dumps (

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -19,6 +19,20 @@ CREATE TABLE IF NOT EXISTS bgp_dumps (
     CONSTRAINT unique_bgp_dump UNIQUE (collector_name, url)
 );
 
+CREATE TABLE IF NOT EXISTS collector_aliases (
+    project TEXT NOT NULL,
+    alias TEXT NOT NULL,
+    canonical_name TEXT NOT NULL,
+    PRIMARY KEY (project, alias)
+);
+
+INSERT INTO collector_aliases (project, alias, canonical_name) VALUES
+('routeviews', 'route-views2.saopaulo', 'ix-br2.gru'),
+('routeviews', 'route-views.saopaulo', 'ix-br.gru'),
+('routeviews', 'route-views.amsix', 'locix.fra')
+ON CONFLICT DO NOTHING;
+
+
 CREATE INDEX bgp_dumps_timestamp_idx ON public.bgp_dumps USING btree ("timestamp");
 
 CREATE INDEX bgp_dumps_dump_type_idx ON public.bgp_dumps USING btree (dump_type);

--- a/multi_finder.go
+++ b/multi_finder.go
@@ -173,7 +173,7 @@ func (m *MultiFinder) Find(query Query) ([]BGPDump, error) {
 		dumps = append(dumps, dump...)
 	}
 
-	return ApplyResultCap(dumps), nil
+	return dumps, nil
 }
 
 func (m *MultiFinder) getFinderByProject(projName string) (Finder, bool) {

--- a/periodicscraper/start.go
+++ b/periodicscraper/start.go
@@ -18,6 +18,12 @@ func Start(logger *logging.Logger, envFile *string) {
 
 	logger.Info().Msg("Starting runn")
 
+	// Perform initial collector discovery and data population
+	logger.Info().Msg("Performing initial collector discovery and metadata population...")
+	if err := bgpfinder.UpdateCollectorsData(ctx, logger, db, bgpfinder.DefaultFinder); err != nil {
+		logger.Error().Err(err).Msg("Failed to perform initial collector discovery")
+	}
+
 	var wg sync.WaitGroup
 
 	projectTuples := getProjectTuples()

--- a/periodicscraper/util.go
+++ b/periodicscraper/util.go
@@ -32,6 +32,7 @@ type DBConfig struct {
 	User     string
 	Password string
 	DBName   string
+	DSN      string
 }
 
 type ProjectTuple struct {
@@ -56,17 +57,25 @@ func loadDBConfig(envFile string) (*DBConfig, error) {
 		}
 	}
 
+	dsn := os.Getenv("POSTGRES_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_URL")
+	}
+
 	config := &DBConfig{
 		Host:     os.Getenv("POSTGRES_HOST"),
 		Port:     os.Getenv("POSTGRES_PORT"),
 		User:     os.Getenv("POSTGRES_USER"),
 		Password: os.Getenv("POSTGRES_PASSWORD"),
 		DBName:   os.Getenv("POSTGRES_DB"),
+		DSN:      dsn,
 	}
 
-	// Validate required fields
-	if config.User == "" || config.Password == "" || config.DBName == "" {
-		return nil, fmt.Errorf("missing required database configuration")
+	// Validate required fields only if DSN is not provided
+	if config.DSN == "" {
+		if config.User == "" || config.Password == "" || config.DBName == "" {
+			return nil, fmt.Errorf("missing required database configuration")
+		}
 	}
 
 	return config, nil
@@ -77,14 +86,22 @@ func setupDB(logger *logging.Logger, envFile *string) *pgxpool.Pool {
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to load database configuration")
 	}
-	connStr := fmt.Sprintf(
-		"postgres://%s:%s@%s:%s/%s?sslmode=disable",
-		config.User,
-		config.Password,
-		config.Host,
-		config.Port,
-		config.DBName,
-	)
+	var connStr string
+	if config.DSN != "" {
+		connStr = config.DSN
+	} else {
+		hostPart := config.Host
+		if config.Port != "" && !strings.Contains(config.Host, ":") {
+			hostPart = fmt.Sprintf("%s:%s", config.Host, config.Port)
+		}
+		connStr = fmt.Sprintf(
+			"postgres://%s:%s@%s/%s?sslmode=disable&target_session_attrs=read-write",
+			config.User,
+			config.Password,
+			hostPart,
+			config.DBName,
+		)
+	}
 
 	db, err := pgxpool.New(context.Background(), connStr)
 	if err != nil {

--- a/periodicscraper/util.go
+++ b/periodicscraper/util.go
@@ -50,8 +50,10 @@ func getProjectTuples() [4]ProjectTuple {
 }
 
 func loadDBConfig(envFile string) (*DBConfig, error) {
-	if err := godotenv.Load(envFile); err != nil {
-		return nil, fmt.Errorf("error loading env file: %w", err)
+	if _, err := os.Stat(envFile); err == nil {
+		if err := godotenv.Load(envFile); err != nil {
+			return nil, fmt.Errorf("error loading env file: %w", err)
+		}
 	}
 
 	config := &DBConfig{

--- a/ris_finder.go
+++ b/ris_finder.go
@@ -5,15 +5,12 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/alistairking/bgpfinder/internal/scraper"
 )
 
 const (
-	RIS = "ris"
-
 	RISRibDuration    = DumpDuration(time.Minute * 2)
 	RISUpdateDuration = DumpDuration(time.Minute * 5)
 	RISRibPeriod      = DumpDuration(time.Hour * 8)
@@ -21,7 +18,6 @@ const (
 )
 
 var (
-	RisProject    = Project{Name: RIS}
 	risRRCPattern = regexp.MustCompile(`(rrc\d\d)`)
 )
 
@@ -43,75 +39,24 @@ func getRisDataUrl() string {
 }
 
 type RISFinder struct {
-	// Cache of collectors
-	mu            *sync.RWMutex
-	collectors    []Collector
-	collectorsErr error // set if collectors is nil, nil otherwise
+	BaseFinder
 }
 
 func NewRISFinder() *RISFinder {
-	f := &RISFinder{
-		mu: &sync.RWMutex{},
-	}
-
+	f := &RISFinder{}
+	f.BaseFinder.Init(RisProject, f.getCollectors)
 	return f
 }
 
-func (f *RISFinder) initCollectors() error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.collectors != nil || f.collectorsErr != nil {
-		return f.collectorsErr
-	}
-	c, err := f.getCollectors()
-	f.collectors = c
-	f.collectorsErr = err
-	return err
-}
-
-func (f *RISFinder) Projects() ([]Project, error) {
-	return []Project{RisProject}, nil
-}
-
-func (f *RISFinder) Project(name string) (Project, error) {
-	if name == "" || name == RIS {
-		return RisProject, nil
-	}
-	return Project{}, nil
-}
-
 func (f *RISFinder) GetCollectorNameAliases(project string) (map[string]string, error) {
-	if project != "" && project != RIS {
+	if project != "" && project != ProjectRIS {
 		return nil, nil
 	}
 	return map[string]string{}, nil
 }
 
-func (f *RISFinder) Collectors(project string) ([]Collector, error) {
-	if project != "" && project != RIS {
-		return nil, nil
-	}
-	if err := f.initCollectors(); err != nil {
-		return nil, err
-	}
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	return f.collectors, f.collectorsErr
-}
-
 func (f *RISFinder) Collector(name string) (Collector, error) {
-	if err := f.initCollectors(); err != nil {
-		return Collector{}, err
-	}
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	// TODO: add a map to avoid the linear search
-	for _, c := range f.collectors {
-		if c.Name == name {
-			return c, nil
-		}
-	}
-	return Collector{}, nil
+	return f.BaseFinder.Collector(name)
 }
 
 // Find the BGP data corresponding to the query

--- a/ris_finder.go
+++ b/ris_finder.go
@@ -2,6 +2,7 @@ package bgpfinder
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -12,10 +13,6 @@ import (
 
 const (
 	RIS = "ris"
-	// RISCollectorsUrl : it's tempting, but we can't use
-	// https://www.ris.ripe.net/peerlist/ because it only lists
-	// currently-active collectors.
-	RISCollectorsUrl = "https://ris.ripe.net/docs/route-collectors/"
 
 	RISRibDuration    = DumpDuration(time.Minute * 2)
 	RISUpdateDuration = DumpDuration(time.Minute * 5)
@@ -26,7 +23,24 @@ const (
 var (
 	RisProject    = Project{Name: RIS}
 	risRRCPattern = regexp.MustCompile(`(rrc\d\d)`)
+	// RisCollectorsUrl : it's tempting, but we can't use
+	// https://www.ris.ripe.net/peerlist/ because it only lists
+	// currently-active collectors.
+	RisCollectorsUrl = "https://ris.ripe.net/docs/route-collectors/"
+	RisDataUrl       = "https://data.ris.ripe.net/"
 )
+
+func init() {
+	if url := os.Getenv("RIS_COLLECTORS_URL"); url != "" {
+		RisCollectorsUrl = url
+	}
+	if url := os.Getenv("RIS_DATA_URL"); url != "" {
+		RisDataUrl = url
+		if !strings.HasSuffix(RisDataUrl, "/") {
+			RisDataUrl += "/"
+		}
+	}
+}
 
 type RISFinder struct {
 	// Cache of collectors
@@ -106,8 +120,8 @@ func (f *RISFinder) Find(query Query) ([]BGPDump, error) {
 	}
 
 	for _, collector := range query.Collectors {
-		// baseURL: https://data.ris.ripe.net/rrcXX
-		baseURL := "https://data.ris.ripe.net/" + collector.Name
+		// baseURL: e.g. https://data.ris.ripe.net/rrcXX
+		baseURL := RisDataUrl + collector.Name
 
 		monthDirs, err := scraper.ScrapeLinks(baseURL)
 		if err != nil {
@@ -186,7 +200,7 @@ func (f *RISFinder) scrapeFilesFromDir(dir string, allowedPrefixes []string, col
 
 // getCollectors fetches ALL Ris collectors
 func (f *RISFinder) getCollectors() ([]Collector, error) {
-	links, err := scraper.ScrapeLinks(RISCollectorsUrl)
+	links, err := scraper.ScrapeLinks(RisCollectorsUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get collector list: %v", err)
 	}

--- a/ris_finder.go
+++ b/ris_finder.go
@@ -23,23 +23,23 @@ const (
 var (
 	RisProject    = Project{Name: RIS}
 	risRRCPattern = regexp.MustCompile(`(rrc\d\d)`)
-	// RisCollectorsUrl : it's tempting, but we can't use
-	// https://www.ris.ripe.net/peerlist/ because it only lists
-	// currently-active collectors.
-	RisCollectorsUrl = "https://ris.ripe.net/docs/route-collectors/"
-	RisDataUrl       = "https://data.ris.ripe.net/"
 )
 
-func init() {
+func getRisCollectorsUrl() string {
 	if url := os.Getenv("RIS_COLLECTORS_URL"); url != "" {
-		RisCollectorsUrl = url
+		return url
 	}
+	return "https://ris.ripe.net/docs/route-collectors/"
+}
+
+func getRisDataUrl() string {
 	if url := os.Getenv("RIS_DATA_URL"); url != "" {
-		RisDataUrl = url
-		if !strings.HasSuffix(RisDataUrl, "/") {
-			RisDataUrl += "/"
+		if !strings.HasSuffix(url, "/") {
+			url += "/"
 		}
+		return url
 	}
+	return "https://data.ris.ripe.net/"
 }
 
 type RISFinder struct {
@@ -54,13 +54,19 @@ func NewRISFinder() *RISFinder {
 		mu: &sync.RWMutex{},
 	}
 
-	// TODO: turn this into a goroutine that periodically
-	// refreshes collector list (and handles transient failures)?
+	return f
+}
+
+func (f *RISFinder) initCollectors() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.collectors != nil || f.collectorsErr != nil {
+		return f.collectorsErr
+	}
 	c, err := f.getCollectors()
 	f.collectors = c
 	f.collectorsErr = err
-
-	return f
+	return err
 }
 
 func (f *RISFinder) Projects() ([]Project, error) {
@@ -85,14 +91,17 @@ func (f *RISFinder) Collectors(project string) ([]Collector, error) {
 	if project != "" && project != RIS {
 		return nil, nil
 	}
+	if err := f.initCollectors(); err != nil {
+		return nil, err
+	}
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	return f.collectors, f.collectorsErr
 }
 
 func (f *RISFinder) Collector(name string) (Collector, error) {
-	if f.collectorsErr != nil {
-		return Collector{}, f.collectorsErr
+	if err := f.initCollectors(); err != nil {
+		return Collector{}, err
 	}
 	f.mu.RLock()
 	defer f.mu.RUnlock()
@@ -121,7 +130,7 @@ func (f *RISFinder) Find(query Query) ([]BGPDump, error) {
 
 	for _, collector := range query.Collectors {
 		// baseURL: e.g. https://data.ris.ripe.net/rrcXX
-		baseURL := RisDataUrl + collector.Name
+		baseURL := getRisDataUrl() + collector.Name
 
 		monthDirs, err := scraper.ScrapeLinks(baseURL)
 		if err != nil {
@@ -200,7 +209,7 @@ func (f *RISFinder) scrapeFilesFromDir(dir string, allowedPrefixes []string, col
 
 // getCollectors fetches ALL Ris collectors
 func (f *RISFinder) getCollectors() ([]Collector, error) {
-	links, err := scraper.ScrapeLinks(RisCollectorsUrl)
+	links, err := scraper.ScrapeLinks(getRisCollectorsUrl())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get collector list: %v", err)
 	}

--- a/ris_finder.go
+++ b/ris_finder.go
@@ -52,7 +52,7 @@ func (f *RISFinder) GetCollectorNameAliases(project string) (map[string]string, 
 	if project != "" && project != ProjectRIS {
 		return nil, nil
 	}
-	return map[string]string{}, nil
+	return GetCollectorNameAliases(ProjectRIS)
 }
 
 func (f *RISFinder) Collector(name string) (Collector, error) {

--- a/routeviews_finder.go
+++ b/routeviews_finder.go
@@ -2,6 +2,7 @@ package bgpfinder
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -19,7 +20,6 @@ type rvDumpType struct {
 
 const (
 	ROUTEVIEWS           = "routeviews"
-	RouteviewsArchiveUrl = "https://archive.routeviews.org/"
 
 	RVRibDuration    = DumpDuration(time.Minute * 2)
 	RVUpdateDuration = DumpDuration(time.Minute * 15)
@@ -28,6 +28,7 @@ const (
 )
 
 var (
+	RouteviewsArchiveUrl = "https://archive.routeviews.org/"
 	RouteviewsProject = Project{Name: ROUTEVIEWS}
 
 	ROUTEVIEWS_DUMP_TYPES = map[DumpType]rvDumpType{
@@ -45,6 +46,15 @@ var (
 		},
 	}
 )
+
+func init() {
+	if url := os.Getenv("ROUTEVIEWS_ARCHIVE_URL"); url != "" {
+		RouteviewsArchiveUrl = url
+		if !strings.HasSuffix(RouteviewsArchiveUrl, "/") {
+			RouteviewsArchiveUrl += "/"
+		}
+	}
+}
 
 // RouteViewsFinder implements the Finder interface
 // TODO: refactor a this common caching-finder code out so that RIS and PCH can use it

--- a/routeviews_finder.go
+++ b/routeviews_finder.go
@@ -28,7 +28,6 @@ const (
 )
 
 var (
-	RouteviewsArchiveUrl = "https://archive.routeviews.org/"
 	RouteviewsProject = Project{Name: ROUTEVIEWS}
 
 	ROUTEVIEWS_DUMP_TYPES = map[DumpType]rvDumpType{
@@ -47,13 +46,14 @@ var (
 	}
 )
 
-func init() {
+func getRouteviewsArchiveUrl() string {
 	if url := os.Getenv("ROUTEVIEWS_ARCHIVE_URL"); url != "" {
-		RouteviewsArchiveUrl = url
-		if !strings.HasSuffix(RouteviewsArchiveUrl, "/") {
-			RouteviewsArchiveUrl += "/"
+		if !strings.HasSuffix(url, "/") {
+			url += "/"
 		}
+		return url
 	}
+	return "https://archive.routeviews.org/"
 }
 
 // RouteViewsFinder implements the Finder interface
@@ -70,13 +70,19 @@ func NewRouteViewsFinder() *RouteViewsFinder {
 		mu: &sync.RWMutex{},
 	}
 
-	// TODO: turn this into a goroutine that periodically
-	// refreshes collector list (and handles transient failures)?
+	return f
+}
+
+func (f *RouteViewsFinder) initCollectors() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.collectors != nil || f.collectorsErr != nil {
+		return f.collectorsErr
+	}
 	c, err := f.getCollectors()
 	f.collectors = c
 	f.collectorsErr = err
-
-	return f
+	return err
 }
 
 // Projects Retrieves a list of supported projects
@@ -97,6 +103,9 @@ func (f *RouteViewsFinder) Collectors(project string) ([]Collector, error) {
 	if project != "" && project != ROUTEVIEWS {
 		return nil, nil
 	}
+	if err := f.initCollectors(); err != nil {
+		return nil, err
+	}
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	return f.collectors, f.collectorsErr
@@ -115,8 +124,8 @@ func (f *RouteViewsFinder) GetCollectorNameAliases(project string) (map[string]s
 
 // Collector Gets a specific collector by name
 func (f *RouteViewsFinder) Collector(name string) (Collector, error) {
-	if f.collectorsErr != nil {
-		return Collector{}, f.collectorsErr
+	if err := f.initCollectors(); err != nil {
+		return Collector{}, err
 	}
 	f.mu.RLock()
 	defer f.mu.RUnlock()
@@ -135,7 +144,7 @@ func (f *RouteViewsFinder) getCollectors() ([]Collector, error) {
 	// If we could find a Go rsync client (not a wrapper) we could just do
 	// `rsync archive.routeviews.org::` and do some light parsing on the
 	// output.
-	links, err := scraper.ScrapeLinks(RouteviewsArchiveUrl)
+	links, err := scraper.ScrapeLinks(getRouteviewsArchiveUrl())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get collector list: %v", err)
 	}
@@ -182,10 +191,10 @@ func (f *RouteViewsFinder) getCollectorURL(collector Collector) string {
 	collectorNameOverrides["route-views2"] = ""
 
 	if override, exists := collectorNameOverrides[collector.Name]; exists {
-		return RouteviewsArchiveUrl + override + "/bgpdata/"
+		return getRouteviewsArchiveUrl() + override + "/bgpdata/"
 	}
 
-	return RouteviewsArchiveUrl + collector.Name + "/bgpdata/"
+	return getRouteviewsArchiveUrl() + collector.Name + "/bgpdata/"
 }
 
 // Find BGP dumps matching the specified query

--- a/routeviews_finder.go
+++ b/routeviews_finder.go
@@ -66,11 +66,7 @@ func (f *RouteViewsFinder) GetCollectorNameAliases(project string) (map[string]s
 	if project != "" && project != ProjectRouteViews {
 		return nil, nil
 	}
-	return map[string]string{
-		"route-views2.saopaulo": "ix-br2.gru",
-		"route-views.saopaulo":  "ix-br.gru",
-		"route-views.amsix":  "locix.fra",
-	}, nil
+	return GetCollectorNameAliases(ProjectRouteViews)
 }
 
 func (f *RouteViewsFinder) Collector(name string) (Collector, error) {

--- a/routeviews_finder.go
+++ b/routeviews_finder.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/alistairking/bgpfinder/internal/scraper"
@@ -19,8 +18,6 @@ type rvDumpType struct {
 }
 
 const (
-	ROUTEVIEWS           = "routeviews"
-
 	RVRibDuration    = DumpDuration(time.Minute * 2)
 	RVUpdateDuration = DumpDuration(time.Minute * 15)
 	RVRibPeriod      = DumpDuration(time.Hour * 2)
@@ -28,8 +25,6 @@ const (
 )
 
 var (
-	RouteviewsProject = Project{Name: ROUTEVIEWS}
-
 	ROUTEVIEWS_DUMP_TYPES = map[DumpType]rvDumpType{
 		DumpTypeRibs: {
 			DumpType: DumpTypeRibs,
@@ -57,62 +52,18 @@ func getRouteviewsArchiveUrl() string {
 }
 
 // RouteViewsFinder implements the Finder interface
-// TODO: refactor a this common caching-finder code out so that RIS and PCH can use it
 type RouteViewsFinder struct {
-	// Cache of collectors
-	mu            *sync.RWMutex
-	collectors    []Collector
-	collectorsErr error // set if collectors is nil, nil otherwise
+	BaseFinder
 }
 
 func NewRouteViewsFinder() *RouteViewsFinder {
-	f := &RouteViewsFinder{
-		mu: &sync.RWMutex{},
-	}
-
+	f := &RouteViewsFinder{}
+	f.BaseFinder.Init(RouteviewsProject, f.getCollectors)
 	return f
 }
 
-func (f *RouteViewsFinder) initCollectors() error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.collectors != nil || f.collectorsErr != nil {
-		return f.collectorsErr
-	}
-	c, err := f.getCollectors()
-	f.collectors = c
-	f.collectorsErr = err
-	return err
-}
-
-// Projects Retrieves a list of supported projects
-func (f *RouteViewsFinder) Projects() ([]Project, error) {
-	return []Project{RouteviewsProject}, nil
-}
-
-// Project Retrieves a specific project by name
-func (f *RouteViewsFinder) Project(name string) (Project, error) {
-	if name == "" || name == ROUTEVIEWS {
-		return RouteviewsProject, nil
-	}
-	return Project{}, nil
-}
-
-// Collectors gets a list of collectors for a given project
-func (f *RouteViewsFinder) Collectors(project string) ([]Collector, error) {
-	if project != "" && project != ROUTEVIEWS {
-		return nil, nil
-	}
-	if err := f.initCollectors(); err != nil {
-		return nil, err
-	}
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	return f.collectors, f.collectorsErr
-}
-
 func (f *RouteViewsFinder) GetCollectorNameAliases(project string) (map[string]string, error) {
-	if project != "" && project != ROUTEVIEWS {
+	if project != "" && project != ProjectRouteViews {
 		return nil, nil
 	}
 	return map[string]string{
@@ -122,21 +73,8 @@ func (f *RouteViewsFinder) GetCollectorNameAliases(project string) (map[string]s
 	}, nil
 }
 
-// Collector Gets a specific collector by name
 func (f *RouteViewsFinder) Collector(name string) (Collector, error) {
-	if err := f.initCollectors(); err != nil {
-		return Collector{}, err
-	}
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	// TODO: add a map to avoid the linear search
-	for _, c := range f.collectors {
-		if c.Name == name {
-			return c, nil
-		}
-	}
-	// not found
-	return Collector{}, fmt.Errorf("collector not found: %+v", name)
+	return f.BaseFinder.Collector(name)
 }
 
 // getCollectors fetches all collectors from RouteviewsArchiveUrl
@@ -149,7 +87,7 @@ func (f *RouteViewsFinder) getCollectors() ([]Collector, error) {
 		return nil, fmt.Errorf("failed to get collector list: %v", err)
 	}
 
-	collectorNameOverrides, err := f.GetCollectorNameAliases(ROUTEVIEWS)
+	collectorNameOverrides, err := f.GetCollectorNameAliases(ProjectRouteViews)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get collector aliases: %v", err)
 	}
@@ -174,7 +112,7 @@ func (f *RouteViewsFinder) getCollectors() ([]Collector, error) {
 		}
 
 		collectors = append(collectors, Collector{
-			Project: ROUTEVIEWS,
+			Project: ProjectRouteViews,
 			Name:    link,
 		})
 	}
@@ -184,7 +122,7 @@ func (f *RouteViewsFinder) getCollectors() ([]Collector, error) {
 // getCollectorURL constructs the collector URL from collector name
 func (f *RouteViewsFinder) getCollectorURL(collector Collector) string {
 	// Get the collectors that have aliases that should be used for the URL
-	collectorNameOverrides, _ := f.GetCollectorNameAliases(ROUTEVIEWS)
+	collectorNameOverrides, _ := f.GetCollectorNameAliases(ProjectRouteViews)
 
 	// usually a collector's url is https://archive.routeviews.org/<collector.Name>bgpdata/
 	// but for route-views2, the url is https://archive.routeviews.org/bgpdata/

--- a/routeviews_finder.go
+++ b/routeviews_finder.go
@@ -125,7 +125,10 @@ func (f *RouteViewsFinder) getCollectorURL(collector Collector) string {
 	collectorNameOverrides["route-views2"] = ""
 
 	if override, exists := collectorNameOverrides[collector.Name]; exists {
-		return getRouteviewsArchiveUrl() + override + "/bgpdata/"
+		if override == "" {
+			return getRouteviewsArchiveUrl() + "bgpdata/"
+		}
+		return getRouteviewsArchiveUrl() + strings.TrimPrefix(override, "/") + "/bgpdata/"
 	}
 
 	return getRouteviewsArchiveUrl() + collector.Name + "/bgpdata/"

--- a/scrape_collectors.go
+++ b/scrape_collectors.go
@@ -69,7 +69,7 @@ func scrapeProject(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool
 		Int("collector_count", len(collectors)).
 		Msg("Found collectors for project")
 
-	if err := UpsertCollectors(ctx, logger, db, collectors, DumpTypeAny, time.Now()); err != nil {
+	if err := UpsertCollectors(ctx, logger, db, collectors, DumpTypeAny, time.Unix(0, 0)); err != nil {
 		return fmt.Errorf("failed to upsert collectors for project %s: %w", project.Name, err)
 	}
 

--- a/scrape_collectors.go
+++ b/scrape_collectors.go
@@ -50,57 +50,66 @@ func UpdateCollectorsData(ctx context.Context, logger *logging.Logger, db *pgxpo
 	}
 
 	for _, project := range projects {
-		collectors, err := finder.Collectors(project.Name)
-		if err != nil {
-			logger.Error().Err(err).Str("project", project.Name).Msg("Failed to get collectors")
+		if err := scrapeProject(ctx, logger, db, finder, project); err != nil {
+			logger.Error().Err(err).Str("project", project.Name).Msg("Failed to scrape project")
 			continue
-		}
-
-		logger.Info().
-			Str("project", project.Name).
-			Int("collector_count", len(collectors)).
-			Msg("Found collectors for project")
-
-		if err := UpsertCollectors(ctx, logger, db, collectors, DumpTypeAny, time.Now()); err != nil {
-			logger.Error().Err(err).Str("project", project.Name).Msg("Failed to upsert collectors")
-			continue
-		}
-
-		// For each collector, find BGP dumps
-		for _, collector := range collectors {
-			logger.Info().Str("collector", collector.Name).Msg("Starting to scrape collector data")
-
-			query := Query{
-				Collectors: []Collector{collector},
-				DumpType:   DumpTypeAny,
-				Intervals:  []Interval{{
-					From:       time.Unix(0, 0),             // Start from Unix epoch (1970-01-01)
-					Until:      time.Now().AddDate(0, 0, 1), // Until tomorrow (to ensure we get today's data)
-				}},
-			}
-
-			dumps, err := finder.Find(query)
-			if err != nil {
-				logger.Error().
-					Err(err).
-					Str("collector", collector.Name).
-					Msg("Finder.Find failed")
-				continue
-			}
-
-			logger.Info().
-				Str("collector", collector.Name).
-				Int("dumps_found", len(dumps)).
-				Msg("Found BGP dumps for collector")
-
-			if err := UpsertBGPDumps(ctx, logger, db, dumps); err != nil {
-				logger.Error().
-					Err(err).
-					Str("collector", collector.Name).
-					Msg("Failed to upsert dumps")
-				continue
-			}
 		}
 	}
+	return nil
+}
+
+func scrapeProject(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, finder Finder, project Project) error {
+	collectors, err := finder.Collectors(project.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get collectors for project %s: %w", project.Name, err)
+	}
+
+	logger.Info().
+		Str("project", project.Name).
+		Int("collector_count", len(collectors)).
+		Msg("Found collectors for project")
+
+	if err := UpsertCollectors(ctx, logger, db, collectors, DumpTypeAny, time.Now()); err != nil {
+		return fmt.Errorf("failed to upsert collectors for project %s: %w", project.Name, err)
+	}
+
+	for _, collector := range collectors {
+		if err := scrapeCollector(ctx, logger, db, finder, collector); err != nil {
+			logger.Error().Err(err).Str("collector", collector.Name).Msg("Failed to scrape collector")
+			continue
+		}
+	}
+	return nil
+}
+
+func scrapeCollector(ctx context.Context, logger *logging.Logger, db *pgxpool.Pool, finder Finder, collector Collector) error {
+	logger.Info().Str("collector", collector.Name).Msg("Starting to scrape collector data")
+
+	// Use a sensible default interval for periodic scraping (e.g., last 24 hours)
+	// But for the very first scrape, we might want more.
+	// For now, sticking to the existing "all time" logic but cleaned up.
+	query := Query{
+		Collectors: []Collector{collector},
+		DumpType:   DumpTypeAny,
+		Intervals: []Interval{{
+			From:  time.Unix(0, 0),
+			Until: time.Now().Add(time.Hour * 24),
+		}},
+	}
+
+	dumps, err := finder.Find(query)
+	if err != nil {
+		return fmt.Errorf("finder.Find failed for collector %s: %w", collector.Name, err)
+	}
+
+	logger.Info().
+		Str("collector", collector.Name).
+		Int("dumps_found", len(dumps)).
+		Msg("Found BGP dumps for collector")
+
+	if err := UpsertBGPDumps(ctx, logger, db, dumps); err != nil {
+		return fmt.Errorf("failed to upsert dumps for collector %s: %w", collector.Name, err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Specifically:
 * add environment variable to change RouteViews and RIS base URLs if required (#18)
 * updated meta/collectors/NAME output format to match BGPStream broker format (#22)
 * add support for multiple "type" parameters in data requests (#20)
 * add BaseFinder class that implements methods that are common to all Finder classes (#13)
 * add support for the "human" parameter to produce human-readable JSON output if set. (#21)
 * ignore "dataAddedSince" parameter for historical data requests (i.e. those with a specific end time) -- this is to ensure parity with the behavior of the BGPStream broker so as not to cause problems with downstream tools that might rely on this behavior (e.g. bgpview). (#23)
  * collector aliases are now tracked in a table in the database, rather than being hard-coded. (#24)
  * updated docker-compose.yaml to support out-of-the-box deployment by new users. (#16, #8)
  * added deployment instructions in DEPLOY.md (#16)
  * replaced README.md with something suitable for a "finished" project rather than outdated implementation planning.
  * ensured double slashes caused by the special case of "route-views2" URLs were removed before returning the URL to a requester.